### PR TITLE
Specyfing encoding explicitly

### DIFF
--- a/src/nanoc/nanoc.yaml
+++ b/src/nanoc/nanoc.yaml
@@ -38,6 +38,7 @@ data_sources:
     # The type is the identifier of the data source. By default, this will be
     # `filesystem_unified`.
     type: filesystem_unified
+    encoding: utf-8
 
     # The path where items should be mounted (comparable to mount points in
     # Unix-like systems). This is “/” by default, meaning that items will have


### PR DESCRIPTION
As described in http://nanoc.ws/docs/troubleshooting/#characters-don-t-show-up-right-in-the-output.
