### PR TITLE
Remove reference to :keybindings command

### DIFF
--- a/src/reference/04-Howto/05-Howto-Interactive-Mode.md
+++ b/src/reference/04-Howto/05-Howto-Interactive-Mode.md
@@ -64,29 +64,6 @@ Some commands have different levels of completion. Hitting tab multiple
 times increases the verbosity of completions. (Presently, this feature
 is only used by the `set` command.)
 
-<a name="show_keybindings"></a>
-
-### Show JLine keybindings
-
-Both the Scala and sbt command prompts use JLine for interaction. The
-Scala REPL contains a `:keybindings` command to show many of the
-keybindings used for JLine. For sbt, this can be used by running one of
-the `console` commands (`console`, `consoleQuick`, or `consoleProject`)
-and then running `:keybindings`. For example:
-
-```
-> consoleProject
-[info] Starting scala interpreter...
-...
-scala> :keybindings
-Reading jline properties for default key bindings.
-Accuracy not guaranteed: treat this as a guideline only.
-
-1 CTRL-A: move to the beginning of the line
-2 CTRL-B: move to the previous character
-...
-```
-
 <a name="change_keybindings"></a>
 
 ### Modify the default JLine keybindings


### PR DESCRIPTION
The :keybindings command is not supported in recent versions of the Scala repl. It would be nice to explain some other way to get that same information here, but I don't know if there is anything comparatively simple. For now I think this text should just go away, so that people aren't scratching their head wondering why it doesn't work.
