### PR TITLE
Add sbt-cppp

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -169,6 +169,8 @@ your plugin to the list.
     <https://github.com/eed3si9n/scalaxb>
 -   sbt-protobuf (Google Protocol Buffers):
     <https://github.com/sbt/sbt-protobuf>
+-   sbt-cppp (Cross-Project Protobuf Plugin for Sbt):
+    <https://github.com/Atry/sbt-cppp>
 -   sbt-avro (Apache Avro): <https://github.com/cavorite/sbt-avro>
 -   sbt-xjc (XSD binding, using
     [JAXB XJC](http://download.oracle.com/javase/6/docs/technotes/tools/share/xjc.html) ):


### PR DESCRIPTION
**sbt-cppp** (**Sbt** <strong>C</strong>ross-<strong>P</strong>roject <strong>P</strong>rotobuf <strong>P</strong>lugin) is a [Sbt](http://www.scala-sbt.org/) plugin to support [Protocol Buffers](http://code.google.com/p/protobuf/), especially in multi-project builds.

https://github.com/Atry/sbt-cppp/
