### PR TITLE
Add sbt-haxe

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -161,6 +161,8 @@ your plugin to the list.
 
 #### Code generator plugins
 
+-   sbt-haxe (Compiling [Haxe](http://www.haxe.org/) to Java):
+    <https://bitbucket.org/qforce/sbt-haxe>
 -   sbt-scalabuff (Google Protocol Buffers with native scala suppport
     thru ScalaBuff): <https://github.com/sbt/sbt-scalabuff>
 -   sbt-fmpp (FreeMarker Scala/Java Templating):


### PR DESCRIPTION
**sbt-haxe** is a [Sbt](http://www.scala-sbt.org/) plugin to compile [Haxe](http://www.haxe.org/) sources in Java/Scala projects.

https://bitbucket.org/qforce/sbt-haxe
