### PR TITLE
Update 02-Community-Plugins.md

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -295,8 +295,7 @@ your plugin to the list.
 -   sbt-scct: <https://github.com/sqality/sbt-scct>
 -   sbt-scoverage: <https://github.com/scoverage/sbt-scoverage>
 -   jacoco4sbt: <https://github.com/sbt/jacoco4sbt>
--   xsbt-coveralls-plugin:
-    <https://github.com/theon/xsbt-coveralls-plugin>
+-   sbt-coveralls: <https://github.com/scoverage/sbt-coveralls>
 
 #### Android plugin
 


### PR DESCRIPTION
The original xsbt-coveralls-plugin is no longer maintained, and the author now links to the maintained version. This commit updates the link to the maintained version.
