### PR TITLE
Fix 'Deploying to Sonatype' links

### DIFF
--- a/src/reference/01-General-Info/05-Using-Sonatype.md
+++ b/src/reference/01-General-Info/05-Using-Sonatype.md
@@ -35,7 +35,7 @@ i.e., you've just generated it, you'll need to publish it. You can do so
 using the [sbt-pgp][sbt-pgp] plugin:
 
 ```
-pgp-cmd send-key keyname hkp://pool.sks-keyservers.net/
+pgp-cmd send-key keyname hkp://pool.sks-keyservers.net
 ```
 
 (where keyname is the name or email address used when creating the key or


### PR DESCRIPTION
The link to the Sonatype documentation is outdated and the tailing URL of hkp://pool.sks-keyservers.net/ will lead to an error in sbt-pgp:

```
INF: [console logger] dispatch: pool.sks-keyservers.net POST /:11371/pks/add HTTP/1.1
Failed to run pgp-cmd: SendKey(<id>,hkp://pool.sks-keyservers.net/).  
Please report this issue at http://github.com/sbt/sbt-pgp/issues
```
