### PR TITLE
Docs: demo 'global' lib exclusion.

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
@@ -296,6 +296,16 @@ libraryDependencies +=
 
 See [ModuleID](../api/sbt/ModuleID.html) for API details.
 
+To exclude a transitive dependency from all dependencies in a sequence
+you can use a `map` call like this:
+
+```scala
+libraryDependencies ++= Seq(
+  "log4j" % "log4j" % "1.2.15",
+  "more" % "libs" % "1.0"
+).map(_.exclude("commons-logging", "commons-logging"))
+```
+
 ##### Download Sources
 
 Downloading source and API documentation jars is usually handled by an


### PR DESCRIPTION
Add an example of how to exclude a transitive dependency for all dependencies in a sequence.

As I've just learned at http://stackoverflow.com/a/25748761/935239 and thought would be helpful in the reference documentation.

###
Is this well placed in the reference documentation or should it remain on SO?
Note that I didn't build this locally, but used the GitHub editor; but that's what Travis-CI is for, no? :-)