### PR TITLE
Add Activator as an installation option

### DIFF
--- a/src/tutorial/01-Setup/00.md
+++ b/src/tutorial/01-Setup/00.md
@@ -11,6 +11,7 @@ out: Setup.html
   [Windows]: Installing-sbt-on-Windows.html
   [Linux]: Installing-sbt-on-Linux.html
   [Manual-Installation]: Manual-Installation.html
+  [Activator-Installation]: Activator-Installation.html
 
 Installing sbt
 --------------
@@ -25,9 +26,12 @@ To create an sbt project, you'll need to take these steps:
 -   Then move on to [.sbt build definition][Basic-Def] to learn more
     about build definitions.
 
-Ultimately, the installation of sbt boils down to a launcher JAR and a shell script,
-but depending on your platform, we provide several ways to make the process less tedious.
-Head over to the installation steps for [Mac][Mac], [Windows][Windows], [Linux][Linux], or [manual installation][Manual-Installation].
+Ultimately, the installation of sbt boils down to a launcher JAR
+and a shell script, but depending on your platform, we provide
+several ways to make the process less tedious.  Head over to the
+installation steps for [Mac][Mac], [Windows][Windows],
+[Linux][Linux], [Typesafe Activator][Activator-Installation], or
+[manual installation][Manual-Installation].
 
 ### Tips and Notes
 

--- a/src/tutorial/01-Setup/a.md
+++ b/src/tutorial/01-Setup/a.md
@@ -5,7 +5,8 @@ out: Installing-sbt-on-Mac.html
   [ZIP]: $sbt_native_package_base$$app_version$/sbt-$app_version$.zip
   [TGZ]: $sbt_native_package_base$$app_version$/sbt-$app_version$.tgz
   [Manual-Installation]: Manual-Installation.html
- 
+  [Activator-Installation]: Activator-Installation.html
+
 Installing sbt on Mac
 ---------------------
 
@@ -30,6 +31,10 @@ Installing sbt on Mac
 ### Installing from a universal package
 
 Download [ZIP][ZIP] or [TGZ][TGZ] package, and expand it.
+
+### Typesafe Activator
+
+See the [Typesafe Activator instructions][Activator-Installation].
 
 ### Installing manually
 

--- a/src/tutorial/01-Setup/b.md
+++ b/src/tutorial/01-Setup/b.md
@@ -5,6 +5,7 @@ out: Installing-sbt-on-Windows.html
   [MSI]: $sbt_native_package_base$$app_version$/sbt-$app_version$.msi
   [ZIP]: $sbt_native_package_base$$app_version$/sbt-$app_version$.zip
   [TGZ]: $sbt_native_package_base$$app_version$/sbt-$app_version$.tgz
+  [Activator-Installation]: Activator-Installation.html
 
 Installing sbt on Windows
 -------------------------
@@ -16,6 +17,10 @@ Download [msi installer][MSI] and install it.
 ### Installing from a universal package
 
 Download [ZIP][ZIP] or [TGZ][TGZ] package and expand it.
+
+### Typesafe Activator
+
+See the [Typesafe Activator instructions][Activator-Installation].
 
 ### Installing manually
 

--- a/src/tutorial/01-Setup/c.md
+++ b/src/tutorial/01-Setup/c.md
@@ -7,7 +7,8 @@ out: Installing-sbt-on-Linux.html
   [RPM]: $sbt_rpm_package_base$sbt-$app_version$.rpm
   [DEB]: $sbt_deb_package_base$sbt-$app_version$.deb
   [Manual-Installation]: Manual-Installation.html
- 
+  [Activator-Installation]: Activator-Installation.html
+
 Installing sbt on Linux
 -----------------------
 
@@ -55,6 +56,10 @@ To merge sbt from this ebuilds you can do:
 > **Note:** Please report any issues with the ebuild
 > [here](https://github.com/whiter4bbit/overlays/issues).
 
+### Typesafe Activator
+
+See the [Typesafe Activator instructions][Activator-Installation].
+
 ### Installing manually
 
-See instruction to install manually.
+See [instructions to install manually][Manual-Installation].

--- a/src/tutorial/01-Setup/e.md
+++ b/src/tutorial/01-Setup/e.md
@@ -1,0 +1,43 @@
+---
+out: Activator-Installation.html
+---
+
+  [Manual-Installation]: Manual-Installation.html
+
+Installing Typesafe Activator (including sbt)
+---------------------
+
+Typesafe Activator is a custom version of sbt which adds two extra
+commands, `activator ui` and `activator new`. The `activator`
+command is a superset of sbt, in short.
+
+You can obtain Activator from
+[typesafe.com](http://typesafe.com/platform/getstarted).
+
+If you see a command line such as `sbt ~test` in the
+documentation, you will also be able to type `activator ~test`.
+Any Activator project can be opened in sbt and vice versa because
+Activator is "sbt powered."
+
+The Activator download includes an `activator` script and an
+`activator-launch.jar`, which are equivalent to the sbt script and
+launch jar described under
+[manual installation][Manual-Installation].  Here are the
+differences between Activator and a
+[manual installation][Manual-Installation] of sbt:
+
+ * typing `activator` with no arguments will attempt to guess
+   whether to enter `activator shell` or `activator ui` mode;
+   type `activator shell` to force the command line prompt.
+ * `activator new` allows you to create projects from a large
+   [catalog of template projects](https://typesafe.com/activator/templates),
+   for example the `play-scala` template is a skeleton
+   [Play Framework](http://playframework.com) Scala app.
+ * `activator ui` launches a quick start UI that can be used to
+   work through tutorials from the template catalog (many
+   templates in the catalog have accompanying tutorials).
+
+Activator offers two downloads; the small "minimal" download
+contains only the wrapper script and launch jar, while the large
+"full" download contains a preloaded Ivy cache with jars for
+Scala, Akka, and the Play Framework.


### PR DESCRIPTION
This is intended to clear up confusion about how
Activator relates to sbt, and whether people need
both or what. The Activator install page explains
how Activator is different from sbt and how it's
the same. This should avoid a few FAQs, hopefully.