### PR TITLE
Fix Travis instruction on ~/.sbt/boot

### DIFF
--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/04-Travis-CI-with-sbt.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/04-Travis-CI-with-sbt.md
@@ -185,7 +185,7 @@ Next, we can put `cache` section as follows:
 cache:
   directories:
     - \$HOME/.ivy2/cache
-    - \$HOME/.sbt/boot/scala-\$TRAVIS_SCALA_VERSION
+    - \$HOME/.sbt/boot/
 ```
 
 Finally, the following a few lines of cleanup script are added:
@@ -311,7 +311,7 @@ language: scala
 cache:
   directories:
     - \$HOME/.ivy2/cache
-    - \$HOME/.sbt/boot/scala-\$TRAVIS_SCALA_VERSION
+    - \$HOME/.sbt/boot/
 
 # This is an sbt plugin, so this section is for demo purpose
 scala:


### PR DESCRIPTION
Originally reported by @xuwei-k 
The actual boot path is like `~/.sbt/boot/scala-2.10.4/org.scala-sbt/sbt/0.13.7`.

/review @jsuereth, @xuwei-k 