### PR TITLE
Adding link to test reporter plugin

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -61,6 +61,7 @@ your plugin to the list.
 -   sbt-testng-interface: <https://github.com/sbt/sbt-testng-interface>
 -   sbt-doctest: <https://github.com/tkawachi/sbt-doctest>
 -   sbt-cassandra-plugin: <https://github.com/hochgi/sbt-cassandra-plugin>
+-   sbt-tabular-test-reporter: <https://github.com/programmiersportgruppe/sbt-tabular-test-reporter>
 
 #### Code coverage plugins
 


### PR DESCRIPTION
The tabular test reporter produces test results
well suited for further processing and analysis.