### PR TITLE
Add sbt-codedeploy to community plugins

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -130,6 +130,7 @@ your plugin to the list.
     <https://github.com/casualjim/sbt-jelastic-deploy>
 -   sbt-elasticbeanstalk (Deploy WAR files to AWS Elastic Beanstalk): <https://github.com/sqs/sbt-elasticbeanstalk>
 -   sbt-cloudformation (AWS CloudFormation templates and stacks management): <https://github.com/tptodorov/sbt-cloudformation>
+-   sbt-codedeploy: <https://github.com/gilt/sbt-codedeploy>
 -   sbt-heroku: <https://github.com/heroku/sbt-heroku>
 
 #### Monitoring integration plugins


### PR DESCRIPTION
I'd like to add the sbt-codedeploy. Before this gets merged could someone make sure that the plugin adheres to the community standards. I think it does, but this is the first plugin I've contributed to SBT, so I just want to make sure everything's in the right place for this initial release.