### PR TITLE
Add link to sbt-jcheckstyle plugin

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -83,6 +83,8 @@ your plugin to the list.
     extensible source code statistics)
 -   sbt-checkstyle-plugin: <https://github.com/etsy/sbt-checkstyle-plugin>
     (Checkstyle - static analysis for Java code)
+-   sbt-jcheckstyle: <https://github.com/xerial/sbt-jcheckstyle> 
+    (handy checkstyle runner for Java projects)
 
 #### One jar plugins
 


### PR DESCRIPTION
Please add a link to new my sbt plugin that checks code style of Java projects in a handy way: https://github.com/xerial/sbt-jcheckstyle