### PR TITLE
Add shebang for manual unix launch script

### DIFF
--- a/src/tutorial/01-Setup/d.md
+++ b/src/tutorial/01-Setup/d.md
@@ -18,6 +18,7 @@ Create a script to run the jar, by creating `~/bin/sbt` with these
 contents:
 
 ```
+#!/bin/bash
 SBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"
 java \$SBT_OPTS -jar `dirname \$0`/sbt-launch.jar "\$@"
 ```

--- a/src/tutorial/es/01-Setup/d.md
+++ b/src/tutorial/es/01-Setup/d.md
@@ -18,6 +18,7 @@ Cree un script para ejecutar el jar, mediante la creación de `~/bin/sbt`
 con el siguiente contenido:
 
 ```
+#!/bin/bash
 SBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"
 java \$SBT_OPTS -jar `dirname \$0`/sbt-launch.jar "\$@"
 ```

--- a/src/tutorial/ja/01-Setup/d.md
+++ b/src/tutorial/ja/01-Setup/d.md
@@ -16,6 +16,7 @@ out: Manual-Installation.html
 以下のようなスクリプトを `~/bin/sbt` として作成し JAR を起動する:
 
 ```
+#!/bin/bash
 SBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"
 java \$SBT_OPTS -jar `dirname \$0`/sbt-launch.jar "\$@"
 ```

--- a/src/tutorial/zh-cn/01-Setup/d.md
+++ b/src/tutorial/zh-cn/01-Setup/d.md
@@ -15,6 +15,7 @@ out: Manual-Installation.html
 创建一个脚本来运行这个 jar，脚本 `~/bin/sbt` 内容如下:
 
 ```
+#!/bin/bash
 SBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"
 java \$SBT_OPTS -jar `路径名 \$0`/sbt-launch.jar "\$@"
 ```


### PR DESCRIPTION
Launching the script from application like emacs doesn't work if there's no shebang in the script.