### PR TITLE
Add sbt-api-mappings

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -178,6 +178,8 @@ your plugin to the list.
     <https://github.com/laughedelic/literator>
 -   sbt-class-diagram (Create a class diagram)
     <https://github.com/xuwei-k/sbt-class-diagram>
+-   sbt-api-mappings (Resolves external links in ScalaDoc for common Scala libraries)
+    <https://github.com/ThoughtWorksInc/sbt-api-mappings>
 
 #### Library dependency plugins
 


### PR DESCRIPTION
sbt-api-mappings is a Sbt plugin that fills apiMappings for common Scala libraries