### PR TITLE
Update links to xsbt-web-plugin

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -142,7 +142,7 @@ your plugin to the list.
 #### Web and frontend development plugins
 
 -   xsbt-web-plugin:
-    <https://github.com/JamesEarlDouglas/xsbt-web-plugin>
+    <https://github.com/earldouglas/xsbt-web-plugin>
 -   xsbt-webstart: <https://github.com/ritschwumm/xsbt-webstart>
 -   sbt-gwt-plugin: <https://github.com/cdietze/sbt-gwt-plugin>
 -   coffeescripted-sbt:

--- a/src/reference/01-General-Info/90-Changes/90-Older-Changes.md
+++ b/src/reference/01-General-Info/90-Changes/90-Older-Changes.md
@@ -206,7 +206,7 @@ Some of the more visible changes:
     sources
 -   Merged plugins and processors into improved plugins system:
     [Plugins][Plugins]
--   [Web application](https://github.com/JamesEarlDouglas/xsbt-web-plugin)
+-   [Web application](https://github.com/earldouglas/xsbt-web-plugin)
     and webstart support moved to plugins instead of core features
 -   Fixed all of the issues in (Google Code) issue #44
 -   Managed dependencies automatically updated when configuration

--- a/src/reference/05-Faq/00.md
+++ b/src/reference/05-Faq/00.md
@@ -618,7 +618,7 @@ parallelExecution := false
 #### What happened to the web development and Web Start support since 0.7?
 
 Web application support was split out into a plugin. See the
-[xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin)
+[xsbt-web-plugin](https://github.com/earldouglas/xsbt-web-plugin)
 project.
 
 For an early version of an xsbt Web Start plugin, visit the

--- a/src/tutorial/10-Using-Plugins.md
+++ b/src/tutorial/10-Using-Plugins.md
@@ -164,7 +164,7 @@ Some especially popular plugins are:
 
 -   those for IDEs (to import an sbt project into your IDE)
 -   those supporting web frameworks, such as
-    [xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin).
+    [xsbt-web-plugin](https://github.com/earldouglas/xsbt-web-plugin).
 
 For more details, including ways of developing plugins, see
 [Plugins][Plugins].

--- a/src/tutorial/ja/10-Using-Plugins.md
+++ b/src/tutorial/ja/10-Using-Plugins.md
@@ -147,7 +147,7 @@ lazy val core = (project in file("core")).
 特に人気のプラグインは:
 
  - IDE のためのプラグイン（sbt プロジェクトを好みの IDE にインポートするためのもの）
- - [xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin) のような Web フレームワークをサポートするプラグイン
+ - [xsbt-web-plugin](https://github.com/earldouglas/xsbt-web-plugin) のような Web フレームワークをサポートするプラグイン
 
 プラグイン開発の方法など、プラグインに関する詳細は [Plugins][Plugins] を参照。
 ベストプラクティスを知りたいなら、[ベスト・プラクティス][Plugins-Best-Practices] を見てほしい。

--- a/src/tutorial/zh-cn/10-Using-Plugins.md
+++ b/src/tutorial/zh-cn/10-Using-Plugins.md
@@ -125,7 +125,7 @@ lazy val core = (project in file("core")).
 一些特别流行的插件如下：
 
 -   对 IDE 的支持（为了将 sbt 项目导入到 IDE）
--   对 web 框架的支持，例如[xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin)。
+-   对 web 框架的支持，例如[xsbt-web-plugin](https://github.com/earldouglas/xsbt-web-plugin)。
 
 更多详细信息，包含开发插件的方法，参见[插件][Plugins]。
 关于最佳实践，参见[插件最佳实践][Plugins-Best-Practices]。


### PR DESCRIPTION
[JamesEarlDouglas/xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin) is just a redirect to [earldouglas/xsbt-web-plugin](https://github.com/earldouglas/xsbt-web-plugin).  This patch skips the extra jump.