### PR TITLE
Add link to sbt-frege plugin

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -332,6 +332,8 @@ your plugin to the list.
     <https://github.com/Geal/sbt-clojure>
 -   sbt-build-info-conf (Generates resources.conf file with build information):
     <https://github.com/Sensatus/sbt-build-info-conf>
+-   sbt-frege (Build [Frege](https://github.com/frege/frege) code):
+    <https://github.com/earldouglas/sbt-frege>
 
 #### Game development plugins
 


### PR DESCRIPTION
[sbt-frege](https://github.com/earldouglas/sbt-frege) is an sbt plugin for building [Frege](https://github.com/frege/frege) code, and was recently added to the sbt community repository.  This patch lists it along with the other code generation plugins.