### PR TITLE
reference Tut and WartRemover plugins

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -168,6 +168,7 @@ your plugin to the list.
 
 #### Documentation plugins
 
+-   tut (Scala literate programming): <https://github.com/tpolecat/tut>
 -   sbt-site (Site generation for sbt):
     <https://github.com/sbt/sbt-site>
 -   sbt-lwm (Convert lightweight markup files, e.g., Markdown and

--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -72,6 +72,8 @@ your plugin to the list.
 
 #### Static code analysis plugins
 
+-   wartremover: <https://github.com/puffnfresh/wartremover> (WartRemover -
+    Scala static analysis)
 -   cpd4sbt: <https://github.com/sbt/cpd4sbt> (copy/paste detection,
     works for Scala, too)
 -   findbugs4sbt: <https://github.com/sbt/findbugs4sbt> (FindBugs only


### PR DESCRIPTION
I know people are using this documentation to find plugins for SBT, and two plugins that I think are really worth noting haven't made it in:  Brian McKenna's Wartremover, and Rob Norris's Tut.

I got out-of-memory errors when trying to build the docs, so I apologize for not rigorously testing that these changes are well-formed.  But it's just three lines, so hopefully it's easy enough to check upon inspection.

I tried to format the lines similarly to surrounding lines, though there's some inconsistency across the file.


