### PR TITLE
Reverse nest internal packages in the coding guideline.

### DIFF
--- a/src/reference/03-Developers-Guide/02-Coding-Guideline/00.md
+++ b/src/reference/03-Developers-Guide/02-Coding-Guideline/00.md
@@ -37,7 +37,7 @@ Code against interface.
 
 #### Hide implementation details
 
-The implementation details should be hidden behind `sbt.internal.x` package,
+The implementation details should be hidden behind `sbt.x.internal` package,
 where `x` could be the name of the main package (like `io`).
 
 #### Depend less


### PR DESCRIPTION
Given the way Scala nests things, it makes more sense for internal things to see
package x specific things.