### PR TITLE
Fix documentation about how to load manifst from a file

### DIFF
--- a/src/reference/04-Howto/08-Howto-Package.md
+++ b/src/reference/04-Howto/08-Howto-Package.md
@@ -60,7 +60,8 @@ Or, to read the manifest from a file:
 
 ```scala
 packageOptions in (Compile, packageBin) +=  {
-  val manifest = Using.fileInputStream( in => new java.util.jar.Manifest(in) )
+  val file = new java.io.File("META-INF/MANIFEST.MF")
+  val manifest = Using.fileInputStream(file)( in => new java.util.jar.Manifest(in) )
   Package.JarManifest( manifest )
 }
 ```


### PR DESCRIPTION
The previous code snippet did not compile. We have to specify the file
that needs to be loaded.