### PR TITLE
Launcher related typos

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
@@ -2,7 +2,7 @@
 out: Proxy-Repositories.html
 ---
 
-  [Sbt-Launcher]: Sbt-Launcher.html
+  [Launcher-Configuration]: Launcher-Configuration.html
 
 Proxy Repositories
 ------------------
@@ -45,7 +45,7 @@ is the launcher script.
 
 The repositories file is an external configuration for the Launcher. The
 exact syntax for the configuration file is detailed in the
-[sbt Launcher][Sbt-Launcher].
+[sbt Launcher Configuration][Launcher-Configuration].
 
 Here's an example config:
 

--- a/src/reference/03-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
+++ b/src/reference/03-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
@@ -84,7 +84,7 @@ There are several built-in strings that can be used for common
 repositories:
 
 -   `local` - the local ivy repository `~/.ivy2/local`.
--   `maven-local` - The local maven repository `~/.ivy2/local`.
+-   `maven-local` - The local maven repository `~/.m2/repository`.
 -   `maven-central` - The maven central repository `repo.maven.org`.
 
 Besides built in repositories, other repositories can be configured


### PR DESCRIPTION
- Correct URL to launcher configuration.
- Correct path to local maven repo. I believe this is correct based on the behavior I see. 
