### PR TITLE
Minor grammar fix

### DIFF
--- a/src/tutorial/10-Using-Plugins.md
+++ b/src/tutorial/10-Using-Plugins.md
@@ -90,7 +90,7 @@ lazy val util = (project in file("util")).
   )
 ```
 
-Auto plugins should document whether they need to explicitly enabled. If you're
+Auto plugins should document whether they need to be explicitly enabled. If you're
 curious which auto plugins are enabled for a given project, just run the
 `plugins` command on the sbt console.
 


### PR DESCRIPTION
Sorry, I couldn't help it but either "need to *be* explicitly enabled" or  "need to explicitly *be* enabled" sounds better in my head.