### PR TITLE
Initial port to use sbt-site 1.0.0-RC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/nanoc/output
 src/nanoc/tmp
 
 *.zip
+target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-language: scala
+language: ruby
+rvm: 2.2.3
 cache:
   apt: true
   directories:
-    - $HOME/.ivy2/cache 
+    - $HOME/.ivy2/cache
 script:
   - sbt makeSite
   # Tricks to avoid unnecessary cache updates
@@ -10,16 +11,15 @@ script:
   - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 jdk:
   - oraclejdk7
-notifications:
-  email:
-    - qbranch@typesafe.com
 install:
-  - gem install nanoc:3.6.9
+  - gem install nanoc:4.0.0
   - gem install redcarpet
   - gem install nokogiri
 before_install:
  - sudo add-apt-repository -y ppa:texlive-backports/ppa
+ - echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+ - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
  - sudo apt-get update -qq
- - sudo apt-get install -qq ruby-dev pandoc latex-cjk-all texlive-full
+ - sudo apt-get install -qq sbt ruby-dev pandoc latex-cjk-all texlive-full
 before_script:
-  - export JVM_OPTS="-Xms1024m -Xmx1024m -XX:ReservedCodeCacheSize=128m -XX:MaxPermSize=256m -Xss1m"
+ - export JVM_OPTS="-Xms1024m -Xmx1024m -XX:ReservedCodeCacheSize=128m -XX:MaxPermSize=256m -Xss1m"

--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,30 @@
-import com.typesafe.sbt.site.PamfletSupport
+import com.typesafe.sbt.site.pamflet.PamfletPlugin
+import com.typesafe.sbt.site.util.SiteHelpers
 import Docs._
+
+enablePlugins(NanocPlugin)
 
 lazy val root = (project in file("."))
   .settings(
     organization := "org.scala-sbt",
     name := "website"
   )
-  // landing page
-  .settings(site.settings ++ site.nanocSupport(): _*)
   // Getting Started guide
-  .settings(PamfletSupport.settings(Tutorial) ++
-    site.addMappingsToSiteDir(mappings in Tutorial, s"""$targetSbtBinaryVersion/tutorial"""): _*)
+  .settings(PamfletPlugin.pamfletSettings(Tutorial))
+  .settings(siteSubdirName in Tutorial := s"$targetSbtBinaryVersion/tutorial")
   // Reference
-  .settings(PamfletSupport.settings(Ref) ++
-    site.addMappingsToSiteDir(mappings in Ref, s"""$targetSbtBinaryVersion/docs"""): _*)
+  .settings(PamfletPlugin.pamfletSettings(Ref))
+  .settings(siteSubdirName in Ref := s"$targetSbtBinaryVersion/docs")
   // Redirects
-  .settings(redirectSettings ++
-    site.addMappingsToSiteDir(mappings in Redirect, s"""$targetSbtBinaryVersion/docs"""): _*)
+  .settings(redirectSettings)
+  .settings(SiteHelpers.addMappingsToSiteDir(mappings in Redirect, siteSubdirName in Ref))
   // Github Pages. See project/Docs.scala
-  .settings(customGhPagesSettings: _*)
+  .settings(customGhPagesSettings)
   // NOTE - PDF settings must be done externally like this because pdf generation generically looks
   // through `mappings in Config` for Combined+Pages.md to generate PDF from, and therefore we
   // can't create a circular dpeendnecy by adding it back into the original mappings.
   .settings(Pdf.settings ++
     Pdf.settingsFor(Tutorial, "sbt-tutorial") ++
-    site.addMappingsToSiteDir(mappings in Pdf.generatePdf in Tutorial, s"""$targetSbtBinaryVersion/tutorial""") ++
+    SiteHelpers.addMappingsToSiteDir(mappings in Pdf.generatePdf in Tutorial, siteSubdirName in Tutorial) ++
     Pdf.settingsFor(Ref, "sbt-reference") ++
-    site.addMappingsToSiteDir(mappings in Pdf.generatePdf in Ref, s"""$targetSbtBinaryVersion/docs"""): _*)
+    SiteHelpers.addMappingsToSiteDir(mappings in Pdf.generatePdf in Ref, siteSubdirName in Ref))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0-RC2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.2")


### PR DESCRIPTION
@eed3si9n Next time you go to update the website, would you mind taking a look at this conversion to use the [sbt-site 1.0.0-RC2 release](https://github.com/sbt/sbt-site/tree/release/1.0.0-RC2). I'm not as familiar with the nuances of sbt/website to know if the conversion was successful or not. Certainly push back if there's a better way to test this out.