### PR TITLE
Added missing launcher configuration example

### DIFF
--- a/src/reference/90-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
+++ b/src/reference/90-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
@@ -26,6 +26,34 @@ An error is generated if none of these attempts succeed.
 
 The default configuration file for sbt as an application looks like:
 
+```
+[scala]
+  version: ${sbt.scala.version-auto}
+
+[app]
+  org: ${sbt.organization-org.scala-sbt}
+  name: sbt
+  version: ${sbt.version-read(sbt.version)[0.13.5]}
+  class: ${sbt.main.class-sbt.xMain}
+  components: xsbti,extra
+  cross-versioned: ${sbt.cross.versioned-false}
+
+[repositories]
+  local
+  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  maven-central
+  sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
+
+[boot]
+  directory: ${sbt.boot.directory-${sbt.global.base-${user.home}/.sbt}/boot/}
+
+[ivy]
+  ivy-home: ${sbt.ivy.home-${user.home}/.ivy2/}
+  checksums: ${sbt.checksums-sha1,md5}
+  override-build-repos: ${sbt.override.build.repos-false}
+  repository-config: ${sbt.repository.config-${sbt.global.base-${user.home}/.sbt}/repositories}
+```
+
 Let's look at all the launcher configuration sections in detail:
 
 #### 1. Scala Configuration


### PR DESCRIPTION
I've copied an example from http://www.scala-sbt.org/0.13.5/docs/Launcher/Configuration.html.