### PR TITLE
Use navigator.userAgent for more reliable os detection on Linux Firefox

### DIFF
--- a/src/nanoc/content/arc.js
+++ b/src/nanoc/content/arc.js
@@ -2,7 +2,7 @@ $(function () {
   var os_name = 'Unknown';
   var distro = 'Unknown';
   var packager = 'Unknown';
-  var ua = navigator.appVersion;
+  var ua = navigator.userAgent;
   if (ua.match('Win')) os_name = 'Windows';
   if (ua.match('Mac')) os_name = 'MacOS';
   if (ua.match('X11')) os_name = 'UNIX';


### PR DESCRIPTION
navigator.appVersion only returns "5.0 (X11)" on Firefox Ubuntu so people have to look for sbt Debian packages in the documentation. This navigator.userAgent seems to be more reliable on all platforms.