### PR TITLE
fix specs2 url link. remove unused specs link

### DIFF
--- a/src/reference/ja/00-Getting-Started/08-Library-Dependencies.md
+++ b/src/reference/ja/00-Getting-Started/08-Library-Dependencies.md
@@ -8,7 +8,7 @@ out: Library-Dependencies.html
   [Extra attributes]: https://ant.apache.org/ivy/history/2.3.0-rc1/concept.html#extra
   [through Ivy]: https://ant.apache.org/ivy/history/latest-milestone/concept.html#checksum
   [ScalaCheck]: http://scalacheck.org
-  [specs]: http://code.google.com/p/specs/
+  [Specs2]: http://specs2.org
   [ScalaTest]: http://scalatest.org
   [Basic-Def]: Basic-Def.html
   [Scopes]: Scopes.html


### PR DESCRIPTION
http://www.scala-sbt.org/0.13/docs/ja/Library-Dependencies.html

![Library-Dependencies-ja](https://cloud.githubusercontent.com/assets/389787/17542712/339276f8-5f06-11e6-9cd4-f7e72337a339.png)
