### PR TITLE
Add sbt-web-scalajs to 02-Community-Plugins.md.

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -176,7 +176,7 @@ your plugin to the list.
 -   sbt-js-test (Run javascript tests on the JVM with browser APIs): <https://github.com/joescii/sbt-js-test>
 -   sbt-javafx (Package JavaFX applications): <https://github.com/kavedaa/sbt-javafx>
 -   sbt-phantomjs (Automated installer and configurator for PhantomJS): <https://github.com/saturday06/sbt-phantomjs>
--   sbt-play-scalajs: <https://github.com/vmunier/sbt-play-scalajs>
+-   sbt-web-scalajs: <https://github.com/vmunier/sbt-web-scalajs>
 -   scalatra-sbt: <https://github.com/scalatra/scalatra-sbt>
 -   sbt-scala-js-map (Configures source mapping for Scala.js projects hosted on Github):
     <https://github.com/ThoughtWorksInc/sbt-scala-js-map>


### PR DESCRIPTION
sbt-play-scalajs has been renamed to sbt-web-scalajs because it has no Play dependency, it only depends on sbt-web and Scala.js.