### PR TITLE
Use long key ID instead of short one

### DIFF
--- a/src/reference/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/00-Getting-Started/01-Setup/c.md
@@ -25,7 +25,7 @@ Ubuntu and other Debian-based distributions use the DEB format, but usually you 
 Run the following from the terminal to install `sbt` (You'll need superuser privileges to do so, hence the `sudo`).
 
     echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 99E82A75642AC823
     sudo apt-get update
     sudo apt-get install sbt
 


### PR DESCRIPTION
You can verify the long key ID is the only one corresponding to the short key ID (at present) on the keyserver using the following command:

    gpg --dry-run --keyid-format long --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 642AC823

Using short key IDs is not safe, and there are already real-world attacks out there against this - see https://lkml.org/lkml/2016/8/15/445.