### PR TITLE
Add trailing-slash to sbt-pgp link to fix GA defect

### DIFF
--- a/src/reference/01-General-Info/05-Using-Sonatype.md
+++ b/src/reference/01-General-Info/05-Using-Sonatype.md
@@ -2,7 +2,7 @@
 out: Using-Sonatype.html
 ---
 
-  [sbt-pgp]: http://scala-sbt.org/sbt-pgp
+  [sbt-pgp]: http://scala-sbt.org/sbt-pgp/
 
 Deploying to Sonatype
 ---------------------


### PR DESCRIPTION
Clicking on the sbt-pgp link on

http://www.scala-sbt.org/1.0/docs/Using-Sonatype.html

produce a 404 not found, because Google Analytics is appending a query string:

http://www.scala-sbt.org/sbt-pgp?_ga=1.200222766.1442054452.1475176157

If it's possible for GitHub sites to ignore query strings for files, that would probably also fix this.  Interestingly, though, making it a directory by adding a trailing-slash seems to work regardless of the query string.  e.g.  http://www.scala-sbt.org/sbt-pgp/?_ga=1.200222766.1442054452.1475176157