### PR TITLE
Mention Ruby 2.1 for nanoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 jdk:
   - oraclejdk7
 install:
-  - gem install nanoc:4.0.0
+  - gem install nanoc:4.0.2
   - gem install redcarpet
   - gem install nokogiri
 before_install:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Fork this project, add your plugin and send us a pull request if your plugin is 
 
 ## Setup
 
+Currently, nanoc requires Ruby 2.1 or greater.
+
 You'll need the following gems for running nanoc:
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently, nanoc requires Ruby 2.1 or greater.
 You'll need the following gems for running nanoc:
 
 ```
-$ gem install nanoc:4.0.0
+$ gem install nanoc:4.0.2
 $ gem install redcarpet
 $ gem install nokogiri
 ```


### PR DESCRIPTION
It's not clear what version of Ruby you need to build the nanoc docs, but I noticed that if you update the minor version, you only need Ruby 2.1.  I've updated the documentation and the Travis yml file.

I ran the `makeSite` command with nanoc 4.0.0 and Ruby 2.2.5, then copied the `target` file, then built it with 2.1.10 and nanoc 4.0.2.  Comparing the target file before and after with `diff`, I noticed there were very few differences:  Just the `.manifest` files and the PDFs.
