### PR TITLE
Recommended way to log inside a Setting definition

### DIFF
--- a/src/reference/04-Howto/06-Howto-Logging.md
+++ b/src/reference/04-Howto/06-Howto-Logging.md
@@ -278,3 +278,16 @@ myTask := {
   log.warn("A warning.")
 }
 ```
+
+### Log messages in a setting 
+
+Since settings cannot reference tasks, the special task `streams` 
+cannot be used to provide logging during setting initialization. 
+The recommented way is to use the sLog `SettingKey[Logger]`:
+
+```scala
+mySetting := {
+  val log = sLog.value
+  log.warn("A warning.")
+}
+```


### PR DESCRIPTION
The recommended way to provide logging during setting is missing from the current documentation.