### PR TITLE
change the invalid command to be the new correct one for 0.13.13

### DIFF
--- a/src/reference/00-Getting-Started/02-Hello.md
+++ b/src/reference/00-Getting-Started/02-Hello.md
@@ -16,7 +16,7 @@ This page assumes you've [installed sbt][Setup] 0.13.13 or later.
 If you're using sbt 0.13.13 or later, you can use sbt `new` command to quickly setup a simple Hello world build. Type the following command to the terminal.
 
 ```
-\$ sbt new sbt/scala-seed.g8
+\$ sbt new eed3si9n/hello.g8
 ....
 Minimum Scala build.
 

--- a/src/reference/ja/00-Getting-Started/02-Hello.md
+++ b/src/reference/ja/00-Getting-Started/02-Hello.md
@@ -18,7 +18,7 @@ sbt 0.13.13 以降を使っている場合は、sbt `new`
 以下をターミナルから打ち込む。
 
 ```
-\$ sbt new sbt/scala-seed.g8
+\$ sbt new eed3si9n/hello.g8
 ....
 Minimum Scala build.
 


### PR DESCRIPTION
the command `sbt/scala-seed.g8` is not working, to see https://github.com/sbt/scala-seed.g8, and click the Giter8 hyperlink, you will see that the commd has been changed to be `sbt new eed3si9n/hello.g8`. and this command is working.

Signed-off-by: Xin He <hexin@jiedaibao.com>