### PR TITLE
sbt 1.0 will target scala 2.12

### DIFF
--- a/src/reference/90-Developers-Guide/02-Coding-Guideline/00.md
+++ b/src/reference/90-Developers-Guide/02-Coding-Guideline/00.md
@@ -13,7 +13,7 @@ This page discusses the coding style and other guidelines for sbt 1.0.
 
 ### General goal
 
-sbt 1.0 will primarily target Scala 2.11.
+sbt 1.0 will primarily target Scala 2.12.
 We will cross-build against Scala 2.10.
 
 #### Clean up old deprecation
@@ -22,8 +22,8 @@ Before 1.0 is release, we should clean up deprecations.
 
 #### Aim for zero warnings (except deprecation)
 
-On Scala 2.11 we should aim for zero warnings.
-One exception may be deprecation if it's required for 2.10 cross-building.
+On Scala 2.12 we should aim for zero warnings.
+One exception may be deprecation if it's required for cross-building.
 
 ### Modular design
 


### PR DESCRIPTION
As discussed in https://github.com/sbt/sbt/issues/2389

The docs currently claim we want to cross-build against scala 2.10. Is that still accurate?