### PR TITLE
Tweaks to favour use of the shell

### DIFF
--- a/src/reference/05-Faq/00.md
+++ b/src/reference/05-Faq/00.md
@@ -76,7 +76,7 @@ to `false`. For example,
 
 #### How can I start a Scala interpreter (REPL) with sbt project configuration (dependencies, etc.)?
 
-You may run `sbt console`.
+In sbt's shell run `console`.
 
 ### Build definitions
 

--- a/src/reference/90-Developers-Guide/09-Launcher/01-Launcher-Getting-Started.md
+++ b/src/reference/90-Developers-Guide/09-Launcher/01-Launcher-Getting-Started.md
@@ -183,7 +183,7 @@ it might look like:
  directory: \${user.home}/.myapp/boot
 ```
 
-Then, `sbt publishLocal` or `sbt +publishLocal` the application to make it
+Then, `publishLocal` or `+publishLocal` the application in sbt's shell to make it
 available. For more information, see
 [Launcher Configuration][Launcher-Configuration].
 

--- a/src/reference/90-Developers-Guide/10-DevGuide-Notes/05-Command-Line-Applications.md
+++ b/src/reference/90-Developers-Guide/10-DevGuide-Notes/05-Command-Line-Applications.md
@@ -32,7 +32,7 @@ There are three files in this example:
 To try out this example:
 
 1.  Put the first two files in a new directory
-2.  Run `sbt publishLocal` in that directory
+2.  In sbt's shell run `publishLocal` in that directory
 3.  Run `sbt @path/to/hello.build.properties` to run the application.
 
 Like for sbt itself, you can specify commands from the command line


### PR DESCRIPTION
Fixes #319

For the most part the docs avoid the "sbt X" (e.g "sbt compile") form.
These are just a few trailing cases I found.

To seek and destroy them I used `git grep`. First I found I can exclude
irrelevant paths and files by appending:

    -- ':/' ':/!/src/reference/ja/' ':/!/src/reference/es/' ':/!/src/reference/zh-cn/' ':/!*.js' ':/!*.css'

(from http://stackoverflow.com/a/30084612/463761)

So I ran the following searches with that appended:

    git grep '[^\.]sbt '
    git grep '`[^`]*sbt '
    git grep '  sbt '
    git grep '	sbt'

(that last one is a literal tab, i.e the literal form of \t)