### PR TITLE
Update 02-Community-Plugins.md

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -135,6 +135,7 @@ your plugin to the list.
 -   sbt-start-script: <https://github.com/sbt/sbt-start-script>
 -   xitrum-package (collects dependency .jar files for standalone Scala
     programs): <https://github.com/ngocdaothanh/xitrum-package>
+-   sbt-dist-zip (Create a distributable zip file): <https://github.com/timt/sbt-dist-zip>
 
 #### Deployment integration plugins
 


### PR DESCRIPTION
Added sbt-dist-zip to community plugins page (a really simple sbt plugin that creates a distributable zip file containing the main project artifact and any files that are in src/main/dist)