### PR TITLE
Add sbt-scripted-scalatest to community plugins list

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -67,6 +67,7 @@ your plugin to the list.
 -   sbt-dynamodb: <https://github.com/localytics/sbt-dynamodb> (downloads and runs DynamoDB Local for testing)
 -   sbt-sqs: <https://github.com/localytics/sbt-sqs> (downloads and runs ElasticMQ for testing)
 -   sbt-s3: <https://github.com/localytics/sbt-s3> (downloads and runs S3Proxy for testing)
+-   sbt-scripted-scalatest: <https://github.com/daniel-shuy/scripted-scalatest-sbt-plugin> (test SBT plugins with ScalaTest)
 
 #### Code coverage plugins
 


### PR DESCRIPTION
Added sbt-scripted-scalatest (a plugin to use ScalaTest with scripted-plugin to test SBT plugins)