### PR TITLE
Use the more common formatting for select chains in examples

### DIFF
--- a/src/reference/00-Getting-Started/06-Task-Graph.md
+++ b/src/reference/00-Getting-Started/06-Task-Graph.md
@@ -68,8 +68,8 @@ regardless of which line it appears in the body.**
 See the following example:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "Hello",
     organization := "com.example",
     scalaVersion := "$example_scala_version$",
@@ -104,8 +104,8 @@ either of them.
 Here's another example:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "Hello",
     organization := "com.example",
     scalaVersion := "$example_scala_version$",
@@ -239,8 +239,8 @@ Let's say it's been set to some values already, but you want to
 filter out `"-Xfatal-warnings"` and `"-deprecation"` for non-2.12.
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "Hello",
     organization := "com.example",
     scalaVersion := "$example_scala_version$",

--- a/src/reference/00-Getting-Started/07A-Scopes.md
+++ b/src/reference/00-Getting-Started/07A-Scopes.md
@@ -271,8 +271,8 @@ If you create a setting in `build.sbt` with a bare key, it will be scoped
 to the current project, configuration `Global` and task `Global`:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "hello"
   )
 ```
@@ -383,13 +383,13 @@ lazy val root = (project in file("."))
     publishLocal := ()
   )
 
-lazy val core = (project in file("core")).
-  settings(
+lazy val core = (project in file("core"))
+  .settings(
     // other settings
   )
 
-lazy val util = (project in file("util")).
-  settings(
+lazy val util = (project in file("util"))
+  .settings(
     // other settings
   )
 ```

--- a/src/reference/00-Getting-Started/09-Multi-Project.md
+++ b/src/reference/00-Getting-Started/09-Multi-Project.md
@@ -59,14 +59,14 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val core = (project in file("core")).
-  settings(
+lazy val core = (project in file("core"))
+  .settings(
     commonSettings,
     // other settings
   )
 
-lazy val util = (project in file("util")).
-  settings(
+lazy val util = (project in file("util"))
+  .settings(
     commonSettings,
     // other settings
   )

--- a/src/reference/00-Getting-Started/10-Using-Plugins.md
+++ b/src/reference/00-Getting-Started/10-Using-Plugins.md
@@ -68,9 +68,9 @@ If you're using an auto plugin that requires explicit enablement, then you
 have to add the following to your `build.sbt`:
 
 ```scala
-lazy val util = (project in file("util")).
-  enablePlugins(FooPlugin, BarPlugin).
-  settings(
+lazy val util = (project in file("util"))
+  .enablePlugins(FooPlugin, BarPlugin)
+  .settings(
     name := "hello-util"
   )
 ```
@@ -83,10 +83,10 @@ method. For example, if we wish to remove the `IvyPlugin` settings
 from `util`, we modify our `build.sbt` as follows:
 
 ```scala
-lazy val util = (project in file("util")).
-  enablePlugins(FooPlugin, BarPlugin).
-  disablePlugins(plugins.IvyPlugin).
-  settings(
+lazy val util = (project in file("util"))
+  .enablePlugins(FooPlugin, BarPlugin)
+  .disablePlugins(plugins.IvyPlugin)
+  .settings(
     name := "hello-util"
   )
 ```
@@ -139,8 +139,8 @@ project:
 lazy val util = (project in file("util"))
 
 // enable the site plugin for the `core` project
-lazy val core = (project in file("core")).
-  settings(site.settings : _*)
+lazy val core = (project in file("core"))
+  .settings(site.settings)
 ```
 
 ### Global plugins

--- a/src/reference/00-Getting-Started/11-Custom-Settings.md
+++ b/src/reference/00-Getting-Started/11-Custom-Settings.md
@@ -69,9 +69,9 @@ lazy val commonSettings = Seq(
   version := "0.1.0-SNAPSHOT"
 )
 
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     sampleStringTask := System.getProperty("user.home"),
     sampleIntTask := {
       val sum = 1 + 2
@@ -130,9 +130,9 @@ lazy val commonSettings = Seq(
   version := "0.1.0-SNAPSHOT"
 )
 
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     startServer := {
       println("starting...")
       Thread.sleep(500)
@@ -216,9 +216,9 @@ on other intermediate tasks. For instance `stopServer` should depend on `sampleS
 at which point `stopServer` should be the `sampleStringTask`.
 
 ```scala
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     startServer := {
       println("starting...")
       Thread.sleep(500)

--- a/src/reference/00-Getting-Started/12-Organizing-Build.md
+++ b/src/reference/00-Getting-Started/12-Organizing-Build.md
@@ -110,9 +110,9 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val backend = (project in file("backend")).
-  settings(commonSettings: _*).
-  settings(
+lazy val backend = (project in file("backend"))
+  .settings(
+    commonSettings,
     libraryDependencies ++= backendDeps
   )
 ```

--- a/src/reference/01-General-Info/04-Bintray-For-Plugins.md
+++ b/src/reference/01-General-Info/04-Bintray-For-Plugins.md
@@ -73,9 +73,9 @@ lazy val commonSettings = Seq(
   organization in ThisBuild := "<INSERT YOUR ORG HERE>"
 )
 
-lazy val root = (project in file(".")).
-  settings(commonSettings).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
+    commonSettings,
     sbtPlugin := true,
     name := "<YOUR PLUGIN HERE>",
     description := "<YOUR DESCRIPTION HERE>",

--- a/src/reference/01-General-Info/90-Changes/48-sbt-0.13-Tech-Previews.md
+++ b/src/reference/01-General-Info/90-Changes/48-sbt-0.13-Tech-Previews.md
@@ -168,8 +168,8 @@ by overriding the `extraProjects` method:
         List("foo", "bar", "baz") map generateProject
 
       def generateProject(id: String): Project =
-        Project(id, file(id)).
-          settings(
+        Project(id, file(id))
+          .settings(
             name := id
           )
     }
@@ -189,8 +189,8 @@ by overriding `derivedProjects`:
         if (proj.projectOrigin != ProjectOrigin.DerivedProject) {
           val id = proj.id + "1"
           Seq(
-            Project(id, file(id)).
-              enablePlugins(DatabasePlugin)
+            Project(id, file(id))
+              .enablePlugins(DatabasePlugin)
           )
         }
         else Nil

--- a/src/reference/02-DetailTopics/02-Configuration/09-Macro-Projects.md
+++ b/src/reference/02-DetailTopics/02-Configuration/09-Macro-Projects.md
@@ -33,16 +33,16 @@ lazy val commonSettings = Seq(
 )
 lazy val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
 
-lazy val core = (project in file("core")).
-  dependsOn(macroSub).
-  settings(commonSettings: _*).
-  settings(
+lazy val core = (project in file("core"))
+  .dependsOn(macroSub)
+  .settings(
+    commonSettings,
     // other settings here
   )
 
-lazy val macroSub = (project in file("macro")).
-  settings(commonSettings: _*).
-  settings(
+lazy val macroSub = (project in file("macro"))
+  .settings(
+    commonSettings,
     libraryDependencies += scalaReflect.value
     // other settings here
   )
@@ -125,24 +125,24 @@ lazy val commonSettings = Seq(
 )
 lazy val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
 
-lazy val core = (project in file("core")).
-  dependsOn(macroSub, util).
-  settings(commonSettings: _*).
-  settings(
+lazy val core = (project in file("core"))
+  .dependsOn(macroSub, util)
+  .settings(
+    commonSettings,
     // other settings here
   )
 
-lazy val macroSub = (project in file("macro")).
-  dependsOn(util).
-  settings(commonSettings: _*).
-  settings(
+lazy val macroSub = (project in file("macro"))
+  .dependsOn(util)
+  .settings(
+    commonSettings,
     libraryDependencies += scalaReflect.value
     // other settings here
   )
 
-lazy util = (project in file("util")).
-  settings(commonSettings: _*).
-  settings(
+lazy util = (project in file("util"))
+  .settings(
+    commonSettings,
     // other setting here
   )
 ```
@@ -159,10 +159,10 @@ publishing. For example, the `core` Project definition above would now
 look like:
 
 ```scala
-lazy val core = (project in file("core")).
-  dependsOn(macroSub % "compile-internal, test-internal").
-  settings(commonSettings: _*).
-  settings(
+lazy val core = (project in file("core"))
+  .dependsOn(macroSub % "compile-internal, test-internal")
+  .settings(
+    commonSettings,
     // include the macro classes and resources in the main jar
     mappings in (Compile, packageBin) ++= mappings.in(macroSub, Compile, packageBin).value,
     // include the macro sources in the main source jar
@@ -174,9 +174,9 @@ You may wish to disable publishing the macro implementation. This is
 done by overriding `publish` and `publishLocal` to do nothing:
 
 ```scala
-lazy val macroSub = (project in file("macro")).
-  settings(commonSettings: _*).
-  settings(
+lazy val macroSub = (project in file("macro"))
+  .settings(
+    commonSettings,
     libraryDependencies += scalaReflect.value,
     publish := {},
     publishLocal := {}

--- a/src/reference/02-DetailTopics/02-Configuration/14-Testing.md
+++ b/src/reference/02-DetailTopics/02-Configuration/14-Testing.md
@@ -260,11 +260,11 @@ lazy val commonSettings = Seq(
 )
 lazy val scalatest = "org.scalatest" %% "scalatest" % "$example_scalatest_version$"
 
-lazy val root = (project in file(".")).
-  configs(IntegrationTest).
-  settings(commonSettings: _*).
-  settings(Defaults.itSettings: _*).
-  settings(
+lazy val root = (project in file("."))
+  .configs(IntegrationTest)
+  .settings(
+    commonSettings,
+    Defaults.itSettings,
     libraryDependencies += scalatest % "it,test"
     // other settings here
   )
@@ -272,7 +272,7 @@ lazy val root = (project in file(".")).
 
 -   `configs(IntegrationTest)` adds the predefined integration test
     configuration. This configuration is referred to by the name it.
--   `settings(Defaults.itSettings : _*)` adds compilation, packaging,
+-   `settings(Defaults.itSettings)` adds compilation, packaging,
     and testing actions and settings in the IntegrationTest
     configuration.
 -   `settings(libraryDependencies += scalatest % "it,test")` adds scalatest to both the
@@ -331,11 +331,11 @@ lazy val commonSettings = Seq(
 lazy val scalatest = "org.scalatest" %% "scalatest" % "$example_scalatest_version$"
 lazy val FunTest = config("fun") extend(Test)
 
-lazy val root = (project in file(".")).
-  configs(FunTest).
-  settings(commonSettings: _*).
-  settings(inConfig(FunTest)(Defaults.testSettings): _*).
-  settings(
+lazy val root = (project in file("."))
+  .configs(FunTest)
+  .settings(
+    commonSettings,
+    inConfig(FunTest)(Defaults.testSettings),
     libraryDependencies += scalatest % FunTest
     // other settings here
   )
@@ -352,7 +352,7 @@ The `extend(Test)` part means to delegate to `Test` for undefined
 new test configuration is:
 
 ```scala
-settings(inConfig(FunTest)(Defaults.testSettings): _*)
+settings(inConfig(FunTest)(Defaults.testSettings))
 ```
 
 This says to add test and settings tasks in the `FunTest` configuration.
@@ -393,11 +393,11 @@ lazy val FunTest = config("fun") extend(Test)
 def itFilter(name: String): Boolean = name endsWith "ITest"
 def unitFilter(name: String): Boolean = (name endsWith "Test") && !itFilter(name)
 
-lazy val root = (project in file(".")).
-  configs(FunTest).
-  settings(commonSettings: _*).
-  settings(inConfig(FunTest)(Defaults.testTasks): _*).
-  settings(
+lazy val root = (project in file("."))
+  .configs(FunTest)
+  .settings(
+    commonSettings,
+    inConfig(FunTest)(Defaults.testTasks),
     libraryDependencies += scalatest % FunTest,
     testOptions in Test := Seq(Tests.Filter(unitFilter)),
     testOptions in FunTest := Seq(Tests.Filter(itFilter))

--- a/src/reference/02-DetailTopics/03-Dependency-Management/01-Artifacts.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/01-Artifacts.md
@@ -153,8 +153,8 @@ full build configuration, usage looks like:
 
 ```scala
 ...
-lazy val proj = Project(...).
-  settings( addArtifact(...).settings : _* )
+lazy val proj = Project(...)
+  .settings( addArtifact(...).settings )
 ...
 ```
 

--- a/src/reference/02-DetailTopics/04-Tasks-and-Commands/01-Tasks.md
+++ b/src/reference/02-DetailTopics/04-Tasks-and-Commands/01-Tasks.md
@@ -552,8 +552,8 @@ To demonstrate the sequential task, let's create a custom task called `compilech
 ```scala
 lazy val compilecheck = taskKey[Unit]("compile and then scalastyle")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     compilecheck in Compile := Def.sequential(
       compile in Compile,
       (scalastyle in Compile).toTask("")

--- a/src/reference/02-DetailTopics/04-Tasks-and-Commands/03-Commands.md
+++ b/src/reference/02-DetailTopics/04-Tasks-and-Commands/03-Commands.md
@@ -123,9 +123,9 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$",
 )
 
-lazy val root = (project in file(".")).
-  settings(commonSettings: _*).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
+    commonSettings,
     commands ++= Seq(hello, helloAll, failIfTrue, changeColor, printState)
   )
 ```

--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/02-Plugins.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/02-Plugins.md
@@ -58,10 +58,10 @@ Many of the auto plugins automatically add settings into projects,
 however, some may require explicit enablement. Here's an example:
 
 ```scala
-lazy val util = (project in file("util")).
-  enablePlugins(FooPlugin, BarPlugin).
-  disablePlugins(plugins.IvyPlugin).
-  settings(
+lazy val util = (project in file("util"))
+  .enablePlugins(FooPlugin, BarPlugin)
+  .disablePlugins(plugins.IvyPlugin)
+  .settings(
     name := "hello-util"
   )
 ```
@@ -123,8 +123,8 @@ This becomes complicated as the number of plugins increase within an application
 Suppose we have the `SbtLessPlugin` and the `SbtCoffeeScriptPlugin`, which in turn depends on the `SbtJsTaskPlugin`, `SbtWebPlugin`, and `JvmPlugin`. Instead of manually activating all of these plugins, a project can just activate the `SbtLessPlugin` and `SbtCoffeeScriptPlugin` like this:
 
 ```scala
-lazy val root = (project in file(".")).
-  enablePlugins(SbtLessPlugin, SbtCoffeeScriptPlugin)
+lazy val root = (project in file("."))
+  .enablePlugins(SbtLessPlugin, SbtCoffeeScriptPlugin)
 ```
 
 This will pull in the right setting sequence from the plugins in the right order.  The key notion here is you declare the plugins you want, and sbt can fill in the gap.
@@ -271,8 +271,8 @@ object SbtLessPlugin extends AutoPlugin {
 As it turns out, `PlayScala` plugin (in case you didn't know, the Play framework is an sbt plugin) lists `SbtJsTaskPlugin` as one of it required plugins. So, if we define a `build.sbt` with:
 
 ```scala
-lazy val root = (project in file(".")).
-  enablePlugins(PlayScala)
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala)
 ```
 
 then the setting sequence from `SbtLessPlugin` will be automatically appended somewhere after the settings from `PlayScala`.

--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/03-Plugins-Best-Practices.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/03-Plugins-Best-Practices.md
@@ -267,8 +267,8 @@ settings may be reused:
 ```scala
 import sbtobfuscate.ObfuscatePlugin
 
-lazy val app = (project in file("app")).
-  settings(inConfig(Test)(ObfuscatePlugin.baseObfuscateSettings): _*)
+lazy val app = (project in file("app"))
+  .settings(inConfig(Test)(ObfuscatePlugin.baseObfuscateSettings))
 ```
 
 #### Using a "main" task scope for settings

--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
@@ -52,8 +52,8 @@ Make dir structure `src/sbt-test/<test-group>/<test-name>`. For starters, try so
 Now ready? Create an initial build in `simple`. Like a real build using your plugin. I'm sure you already have several of them to test manually. Here's an example `build.sbt`:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     version := "0.1",
     scalaVersion := "2.10.6",
     assemblyJarName in assembly := "foo.jar"
@@ -137,8 +137,8 @@ The file commands are great, but not nearly enough because none of them test the
 For my hello project, I'd like to check if the resulting jar prints out "hello". I can take advantage of `sbt.Process` to run the jar. To express a failure, just throw an error. Here's `build.sbt`:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     version := "0.1",
     scalaVersion := "2.10.6",
     assemblyJarName in assembly := "foo.jar",

--- a/src/reference/04-Howto/20-Howto-Sequencing/01-Howto-Sequential-Task.md
+++ b/src/reference/04-Howto/20-Howto-Sequencing/01-Howto-Sequential-Task.md
@@ -26,8 +26,8 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 ```scala
 lazy val compilecheck = taskKey[Unit]("compile and then scalastyle")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     compilecheck in Compile := Def.sequential(
       compile in Compile,
       (scalastyle in Compile).toTask("")

--- a/src/reference/04-Howto/20-Howto-Sequencing/02-Howto-Dynamic-Task.md
+++ b/src/reference/04-Howto/20-Howto-Sequencing/02-Howto-Dynamic-Task.md
@@ -29,8 +29,8 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 ```scala
 lazy val compilecheck = taskKey[sbt.inc.Analysis]("compile and then scalastyle")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     compilecheck := (Def.taskDyn {
       val c = (compile in Compile).value
       Def.task {
@@ -48,8 +48,8 @@ Now we have the same thing as the sequential task, except we can now return the 
 If we can return the same return type as `compile in Compile`, might actually rewire the key to our dynamic task.
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     compile in Compile := (Def.taskDyn {
       val c = (compile in Compile).value
       Def.task {

--- a/src/reference/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
+++ b/src/reference/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
@@ -24,8 +24,8 @@ object Greeting extends App {
 ```scala
 lazy val runopen = inputKey[Unit]("run and then open the browser")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     runopen := {
       (run in Compile).evaluated
       println("open browser!")
@@ -48,8 +48,8 @@ open browser!
 We can actually remove `runopen` key, by rewriting the new input task to `run in Compile`:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     run in Compile := {
       (run in Compile).evaluated
       println("open browser!")

--- a/src/reference/04-Howto/20-Howto-Sequencing/04-Howto-Dynamic-Input-Task.md
+++ b/src/reference/04-Howto/20-Howto-Sequencing/04-Howto-Dynamic-Input-Task.md
@@ -12,8 +12,8 @@ Let's suppose that there's a task already that does the bowser opening called `o
 lazy val runopen = inputKey[Unit]("run and then open the browser")
 lazy val openbrowser = taskKey[Unit]("open the browser")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     runopen := (Def.inputTaskDyn {
       import sbt.complete.Parsers.spaceDelimited
       val args = spaceDelimited("<args>").parsed
@@ -37,8 +37,8 @@ To break the cycle, we will introduce a clone of `run in Compile` called `actual
 lazy val actualRun = inputKey[Unit]("The actual run task")
 lazy val openbrowser = taskKey[Unit]("open the browser")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     run in Compile := (Def.inputTaskDyn {
       import sbt.complete.Parsers.spaceDelimited
       val args = spaceDelimited("<args>").parsed

--- a/src/reference/04-Howto/90-Examples/01-Basic-Def-Examples.md
+++ b/src/reference/04-Howto/90-Examples/01-Basic-Def-Examples.md
@@ -29,9 +29,10 @@ lazy val osmlibVersion = "2.5.2-RC1"
 lazy val osmlib = ("net.sf.travelingsales" % "osmlib" % osmlibVersion from
   s"""http://downloads.sourceforge.net/project/travelingsales/libosm/\$osmlibVersion/libosm-\$osmlibVersion.jar""")
 
-lazy val root = (project in file(".")).
-  settings(commonSettings: _*).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
+    commonSettings,
+
     // set the name of the project
     name := "My Project",
 

--- a/src/reference/04-Howto/90-Examples/02-Scala-Files-Example.md
+++ b/src/reference/04-Howto/90-Examples/02-Scala-Files-Example.md
@@ -75,8 +75,8 @@ object ShellPromptPlugin extends AutoPlugin {
     def buffer[T] (f: => T): T = f
   }
   def currBranch =
-    ("git status -sb" lines_! devnull headOption).
-      getOrElse("-").stripPrefix("## ")
+    ("git status -sb" lines_! devnull headOption)
+      .getOrElse("-").stripPrefix("## ")
   val buildShellPrompt: State => String = {
     case (state: State) =>
       val currProject = Project.extract (state).currentProject.id
@@ -127,35 +127,35 @@ lazy val pricingDeps = Seq(
   scalatest % Test
 )
 
-lazy val cdap2 = (project in file(".")).
-  aggregate(common, server, compact, pricing, pricing_service).
-  settings(buildSettings: _*)
+lazy val cdap2 = (project in file("."))
+  .aggregate(common, server, compact, pricing, pricing_service)
+  .settings(buildSettings)
 
-lazy val common = (project in file("cdap2-common")).
-  settings(buildSettings: _*).
-  settings(
+lazy val common = (project in file("cdap2-common"))
+  .settings(
+    buildSettings,
     libraryDependencies ++= commonDeps
   )
 
-lazy val server = (project in file("cdap2-server")).
-  dependsOn(common).
-  settings(buildSettings: _*).
-  settings(
+lazy val server = (project in file("cdap2-server"))
+  .dependsOn(common)
+  .settings(
+    buildSettings,
     resolvers := oracleResolvers,
     libraryDependencies ++= serverDeps
   )
 
-lazy val pricing = (project in file("cdap2-pricing")).
-  dependsOn(common, compact, server).
-  settings(buildSettings: _*).
-  settings(
+lazy val pricing = (project in file("cdap2-pricing"))
+  .dependsOn(common, compact, server)
+  .settings(
+    buildSettings,
     libraryDependencies ++= pricingDeps
   )  
 
-lazy val pricing_service = (project in file("cdap2-pricing-service")).
-  dependsOn(pricing, server).
-  settings(buildSettings: _*)
+lazy val pricing_service = (project in file("cdap2-pricing-service"))
+  .dependsOn(pricing, server)
+  .settings(buildSettings)
 
-lazy val compatct = (project in file("compact-hashmap")).
-  settings(buildSettings: _*)
+lazy val compatct = (project in file("compact-hashmap"))
+  .settings(buildSettings)
 ```

--- a/src/reference/04-Howto/90-Examples/03-Advanced-Configurations-Example.md
+++ b/src/reference/04-Howto/90-Examples/03-Advanced-Configurations-Example.md
@@ -46,24 +46,26 @@ lazy val commonSettings = Seq(
 )
 
 // An example project that only uses the Scalate utilities.
-lazy val a = (project in file("a")).
-  dependsOn(utils % "compile->scalate").
-  settings(commonSettings: _*)
+lazy val a = (project in file("a"))
+  .dependsOn(utils % "compile->scalate")
+  .settings(commonSettings)
 
 // An example project that uses the Scalate and Saxon utilities.
 // For the configurations defined here, this is equivalent to doing dependsOn(utils),
 //  but if there were more configurations, it would select only the Scalate and Saxon
 //  dependencies.
-lazy val b = (project in file("b")).
-  dependsOn(utils % "compile->scalate,saxon").
-  settings(commonSettings: _*)
+lazy val b = (project in file("b"))
+  .dependsOn(utils % "compile->scalate,saxon")
+  .settings(commonSettings)
 
 // Defines the utilities project
-lazy val utils = (project in file("utils")).
-  settings(commonSettings: _*).
-  settings(inConfig(Common)(Defaults.configSettings): _*).  // Add the src/common/scala/ compilation configuration.
-  settings(addArtifact(artifact in (Common, packageBin), packageBin in Common): _*). // Publish the common artifact
-  settings(
+lazy val utils = (project in file("utils"))
+  .settings(
+    commonSettings,
+
+    inConfig(Common)(Defaults.configSettings),  // Add the src/common/scala/ compilation configuration.
+    addArtifact(artifact in (Common, packageBin), packageBin in Common), // Publish the common artifact
+
       // We want our Common sources to have access to all of the dependencies on the classpaths
       //   for compile and test, but when depended on, it should only require dependencies in 'common'
     classpathConfiguration in Common := CustomCompile,

--- a/src/reference/90-Developers-Guide/06-Datatype/00.md
+++ b/src/reference/90-Developers-Guide/06-Datatype/00.md
@@ -39,9 +39,9 @@ Your datatype definitions should be placed by default in `src/main/datatype`
 and `src/test/datatype`. Here's how your build should be configured:
 
 ```scala
-lazy val library = (project in file("library")).
-  enablePlugins(DatatypePlugin).
-  settings(
+lazy val library = (project in file("library"))
+  .enablePlugins(DatatypePlugin)
+  .settings(
     name := "foo library",
   )
 ```
@@ -358,9 +358,9 @@ will still run.
 Adding `JsonCodecPlugin` to the subproject will generate sjson-new JSON codes for
 the datatypes.
 
-lazy val root = (project in file(".")).
-  enablePlugins(DatatypePlugin, JsonCodecPlugin).
-  settings(
+lazy val root = (project in file("."))
+  .enablePlugins(DatatypePlugin, JsonCodecPlugin)
+  .settings(
     scalaVersion := "2.11.8",
     libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % "0.4.1"
   )

--- a/src/reference/90-Developers-Guide/10-DevGuide-Notes/04-Build-Loaders.md
+++ b/src/reference/90-Developers-Guide/10-DevGuide-Notes/04-Build-Loaders.md
@@ -173,7 +173,7 @@ object Demo extends Build
 
     val n = Project.normalizeProjectID(model.getName)
     val base = Option(model.getProjectDirectory) getOrElse info.base
-    val root = Project(n, base) settings( pomSettings(model) : _*)
+    val root = Project(n, base) settings( pomSettings(model) )
     val build = new Build { override def projects = Seq(root) }
     val loader = this.getClass.getClassLoader
     val definitions = new LoadedDefinitions(info.base, Nil, loader, build :: Nil, Nil)

--- a/src/reference/ja/00-Getting-Started/06-Task-Graph.md
+++ b/src/reference/ja/00-Getting-Started/06-Task-Graph.md
@@ -67,8 +67,8 @@ scalacOptions := {
 具体例で説明しよう:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "Hello",
     organization := "com.example",
     scalaVersion := "$example_scala_version$",
@@ -103,8 +103,8 @@ lazy val root = (project in file(".")).
 もう一つの例:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "Hello",
     organization := "com.example",
     scalaVersion := "$example_scala_version$",
@@ -229,8 +229,8 @@ scalacOptions := {
 `"-Xfatal-warnings"` と `"-deprecation"` を除外したいとする。
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "Hello",
     organization := "com.example",
     scalaVersion := "$example_scala_version$",

--- a/src/reference/ja/00-Getting-Started/07A-Scopes.md
+++ b/src/reference/ja/00-Getting-Started/07A-Scopes.md
@@ -210,8 +210,8 @@ sbt シェルで `inspect` コマンドを使ってキーとそのスコープ�
 `build.sbt` で裸のキーを使ってセッティングを作った場合は、現プロジェクト、`Global` コンフィグレーション、`Global` タスクにスコープ付けされる:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "hello"
   )
 ```
@@ -306,13 +306,13 @@ lazy val root = (project in file("."))
     publishLocal := ()
   )
 
-lazy val core = (project in file("core")).
-  settings(
+lazy val core = (project in file("core"))
+  .settings(
     // other settings
   )
 
-lazy val util = (project in file("util")).
-  settings(
+lazy val util = (project in file("util"))
+  .settings(
     // other settings
   )
 ```

--- a/src/reference/ja/00-Getting-Started/09-Multi-Project.md
+++ b/src/reference/ja/00-Getting-Started/09-Multi-Project.md
@@ -54,14 +54,14 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val core = (project in file("core")).
-  settings(
+lazy val core = (project in file("core"))
+  .settings(
     commonSettings,
     // other settings
   )
 
-lazy val util = (project in file("util")).
-  settings(
+lazy val util = (project in file("util"))
+  .settings(
     commonSettings,
     // other settings
   )

--- a/src/reference/ja/00-Getting-Started/10-Using-Plugins.md
+++ b/src/reference/ja/00-Getting-Started/10-Using-Plugins.md
@@ -63,9 +63,9 @@ auto plugin の多くはデフォルトのセッティング群を自動的に�
 明示的な有効化が必要な auto plugin を使っている場合は、以下を `build.sbt` に追加する必要がある:
 
 ```scala
-lazy val util = (project in file("util")).
-  enablePlugins(FooPlugin, BarPlugin).
-  settings(
+lazy val util = (project in file("util"))
+  .enablePlugins(FooPlugin, BarPlugin)
+  .settings(
     name := "hello-util"
   )
 ```
@@ -74,10 +74,10 @@ lazy val util = (project in file("util")).
 例えば、`util` から `IvyPlugin` のセッティングを除外したいとすると、`build.sbt` を以下のように変更する:
 
 ```scala
-lazy val util = (project in file("util")).
-  enablePlugins(FooPlugin, BarPlugin).
-  disablePlugins(plugins.IvyPlugin).
-  settings(
+lazy val util = (project in file("util"))
+  .enablePlugins(FooPlugin, BarPlugin)
+  .disablePlugins(plugins.IvyPlugin)
+  .settings(
     name := "hello-util"
   )
 ```
@@ -127,8 +127,8 @@ site.settings
 lazy val util = (project in file("util"))
 
 // enable the site plugin for the `core` project
-lazy val core = (project in file("core")).
-  settings(site.settings : _*)
+lazy val core = (project in file("core"))
+  .settings(site.settings)
 ```
 
 ### グローバル・プラグイン

--- a/src/reference/ja/00-Getting-Started/11-Custom-Settings.md
+++ b/src/reference/ja/00-Getting-Started/11-Custom-Settings.md
@@ -65,9 +65,9 @@ lazy val commonSettings = Seq(
   version := "0.1.0-SNAPSHOT"
 )
 
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     sampleStringTask := System.getProperty("user.home"),
     sampleIntTask := {
       val sum = 1 + 2
@@ -119,9 +119,9 @@ lazy val commonSettings = Seq(
   version := "0.1.0-SNAPSHOT"
 )
 
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     startServer := {
       println("starting...")
       Thread.sleep(500)
@@ -200,9 +200,9 @@ s: 3
 その時点で `stopServer` は `sampleStringTask` と呼ばれるべきだろう。
 
 ```scala
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     startServer := {
       println("starting...")
       Thread.sleep(500)

--- a/src/reference/ja/00-Getting-Started/12-Organizing-Build.md
+++ b/src/reference/ja/00-Getting-Started/12-Organizing-Build.md
@@ -102,9 +102,9 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val backend = (project in file("backend")).
-  settings(commonSettings: _*).
-  settings(
+lazy val backend = (project in file("backend"))
+  .settings(
+    commonSettings,
     libraryDependencies ++= backendDeps
   )
 ```

--- a/src/reference/ja/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
+++ b/src/reference/ja/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
@@ -53,8 +53,8 @@ scriptedBufferLog := false
 ここがポイントなんだけど、`simple` 下にビルドを作成する。プラグインを使った普通のビルド。手動でテストするために、いくつか既にあると思うけど。以下に、`build.sbt` の例を示す:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     version := "0.1",
     scalaVersion := "2.10.6",
     assemblyJarName in assembly := "foo.jar"
@@ -138,8 +138,8 @@ Running sbt-assembly / simple
 上記の hello プロジェクトを例に取ると、生成された jar が "hello" と表示するかを確認したいとする。`sbt.Process` を用いて jar を走らせることができる。失敗を表すには、単にエラーを投げればいい。以下に `build.sbt` を示す:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     version := "0.1",
     scalaVersion := "2.10.6",
     assemblyJarName in assembly := "foo.jar",

--- a/src/reference/ja/04-Howto/20-Howto-Sequencing/01-Howto-Sequential-Task.md
+++ b/src/reference/ja/04-Howto/20-Howto-Sequencing/01-Howto-Sequential-Task.md
@@ -26,8 +26,8 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 ```scala
 lazy val compilecheck = taskKey[Unit]("compile and then scalastyle")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     compilecheck in Compile := Def.sequential(
       compile in Compile,
       (scalastyle in Compile).toTask("")

--- a/src/reference/ja/04-Howto/20-Howto-Sequencing/02-Howto-Dynamic-Task.md
+++ b/src/reference/ja/04-Howto/20-Howto-Sequencing/02-Howto-Dynamic-Task.md
@@ -28,8 +28,8 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 ```scala
 lazy val compilecheck = taskKey[sbt.inc.Analysis]("compile and then scalastyle")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     compilecheck := (Def.taskDyn {
       val c = (compile in Compile).value
       Def.task {
@@ -47,8 +47,8 @@ lazy val root = (project in file(".")).
 `compile in Compile` の戻り値と同じ型を返せるようになったので、もとのキーをこの動的タスクで再配線 (rewire) できるかもしれない。
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     compile in Compile := (Def.taskDyn {
       val c = (compile in Compile).value
       Def.task {

--- a/src/reference/ja/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
+++ b/src/reference/ja/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
@@ -24,8 +24,8 @@ object Greeting extends App {
 ```scala
 lazy val runopen = inputKey[Unit]("run and then open the browser")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     runopen := {
       (run in Compile).evaluated
       println("open browser!")
@@ -48,8 +48,8 @@ open browser!
 この新しいインプットタスクを `run in Compile` に再配線することで、実は `runopen` キーを外すことができる:
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     run in Compile := {
       (run in Compile).evaluated
       println("open browser!")

--- a/src/reference/ja/04-Howto/20-Howto-Sequencing/04-Howto-Dynamic-Input-Task.md
+++ b/src/reference/ja/04-Howto/20-Howto-Sequencing/04-Howto-Dynamic-Input-Task.md
@@ -12,8 +12,8 @@ out: Howto-Dynamic-Input-Task.html
 lazy val runopen = inputKey[Unit]("run and then open the browser")
 lazy val openbrowser = taskKey[Unit]("open the browser")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     runopen := (Def.inputTaskDyn {
       import sbt.complete.Parsers.spaceDelimited
       val args = spaceDelimited("<args>").parsed
@@ -37,8 +37,8 @@ lazy val root = (project in file(".")).
 lazy val actualRun = inputKey[Unit]("The actual run task")
 lazy val openbrowser = taskKey[Unit]("open the browser")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     run in Compile := (Def.inputTaskDyn {
       import sbt.complete.Parsers.spaceDelimited
       val args = spaceDelimited("<args>").parsed

--- a/src/reference/zh-cn/00-Getting-Started/02-Hello.md
+++ b/src/reference/zh-cn/00-Getting-Started/02-Hello.md
@@ -52,8 +52,8 @@ Hi!
 例如，如果你的项目放在 `hello` 下，在 `hello/build.sbt` 中可以这样写：
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "hello",
     version := "1.0",
     scalaVersion := "$example_scala_version$"

--- a/src/reference/zh-cn/00-Getting-Started/05-Basic-Def.md
+++ b/src/reference/zh-cn/00-Getting-Started/05-Basic-Def.md
@@ -47,8 +47,8 @@ lazy val root = (project in file("."))
 你可以为本目录下的项目名称关联一个 `Setting[String]`，像这样：
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "hello"
   )
 ```
@@ -73,9 +73,9 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val root = (project in file(".")).
-  settings(commonSettings: _*).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
+    commonSettings,
     name := "hello"
   )
 ```
@@ -91,8 +91,8 @@ key 的类别将在下面讲解。
 键（Keys）有一个返回 `Setting[T]` 的 `:=` 方法。你可以像使用 Java 的语法一样调用该方法：
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name.:=("hello")
   )
 ```
@@ -105,8 +105,8 @@ lazy val root = (project in file(".")).
 如果你使用了错误类型的 value，构建定义会编译不通过：
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := 42  // 编译不通过
   )
 ```
@@ -159,8 +159,8 @@ sbt 描述项目的 map 会将设置（setting）保存为固定的字符串，�
 ```scala
 lazy val hello = taskKey[Unit]("An example task")
 
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     hello := { println("Hello!") }
   )
 ```
@@ -168,8 +168,8 @@ lazy val root = (project in file(".")).
 我们已经在定义项目名称时见过定义 settings 的例子，
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "hello"
   )
 ```
@@ -217,9 +217,9 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val root = (project in file(".")).
-  settings(commonSettings: _*).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
+    commonSettings,
     name := "hello",
     libraryDependencies += derby
   )

--- a/src/reference/zh-cn/00-Getting-Started/06-Scopes.md
+++ b/src/reference/zh-cn/00-Getting-Started/06-Scopes.md
@@ -187,8 +187,8 @@ Settings 可以影响一个 task 如何工作。例如，task `packageSrc` 就�
 如果你创建的 `build.sbt` 中有一个bare key，它的作用于将是当前的 project 下，configuration 和 task 均为 `Global`：
 
 ```scala
-lazy val root = (project in file(".")).
-  settings(
+lazy val root = (project in file("."))
+  .settings(
     name := "hello"
   )
 ```

--- a/src/reference/zh-cn/00-Getting-Started/09-Multi-Project.md
+++ b/src/reference/zh-cn/00-Getting-Started/09-Multi-Project.md
@@ -38,8 +38,8 @@ lazy val core = project in file("core")
 
 #### 公共设定
 
-To factor out common settings across multiple projects, create a sequence named `commonSettings` and call `settings` method on each project. Note `_*` is required to pass sequence into a vararg method.
-要跨多个项目提取公共设置，请创建一个名为`commonSettings`的序列，并在每个项目上调用`settings`方法。注意要传入序列给变参数方法时需要调用`_*`。
+To factor out common settings across multiple projects, create a sequence named `commonSettings` and call `settings` method on each project.
+要跨多个项目提取公共设置，请创建一个名为`commonSettings`的序列，并在每个项目上调用`settings`方法。
 
 ```scala
 lazy val commonSettings = Seq(
@@ -48,15 +48,15 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val core = (project in file("core")).
-  settings(commonSettings: _*).
-  settings(
+lazy val core = (project in file("core"))
+  .settings(
+    commonSettings,
     // other settings
   )
 
-lazy val util = (project in file("util")).
-  settings(commonSettings: _*).
-  settings(
+lazy val util = (project in file("util"))
+  .settings(
+    commonSettings,
     // other settings
   )
 ```
@@ -84,9 +84,9 @@ lazy val core = project
 *在进行聚合的项目中*，像这个例子中的 root 项目一样，你可以按 task 来控制聚合。例如，为了避免聚合 `update` task：
 
 ```scala
-lazy val root = (project in file(".")).
-  aggregate(util, core).
-  settings(
+lazy val root = (project in file("."))
+  .aggregate(util, core)
+  .settings(
     aggregate in update := false
   )
 

--- a/src/reference/zh-cn/00-Getting-Started/10-Using-Plugins.md
+++ b/src/reference/zh-cn/00-Getting-Started/10-Using-Plugins.md
@@ -50,9 +50,9 @@ resolvers += Resolver.sonatypeRepo("public")
 如果你正在使用一个需要显示开启的自动插件，那么你需要添加这样的代码到你的 `build.sbt` 文件：
 
 ```scala
-lazy val util = (project in file("util")).
-  enablePlugins(FooPlugin, BarPlugin).
-  settings(
+lazy val util = (project in file("util"))
+  .enablePlugins(FooPlugin, BarPlugin)
+  .settings(
     name := "hello-util"
   )
 ```
@@ -62,10 +62,10 @@ lazy val util = (project in file("util")).
 项目也可以使用 `disablePlugins` 方法排除掉一些插件。例如，如果我们希望能够从 `util` 中移除 `IvyPlugin` 插件的设置，我们将 `build.sbt` 修改如下：
 
 ```scala
-lazy val util = (project in file("util")).
-  enablePlugins(FooPlugin, BarPlugin).
-  disablePlugins(plugins.IvyPlugin).
-  settings(
+lazy val util = (project in file("util"))
+  .enablePlugins(FooPlugin, BarPlugin)
+  .disablePlugins(plugins.IvyPlugin)
+  .settings(
     name := "hello-util"
   )
 ```
@@ -106,8 +106,8 @@ site.settings
 lazy val util = (project in file("util"))
 
 // 在`core` 项目中开启 site 插件
-lazy val core = (project in file("core")).
-  settings(site.settings : _*)
+lazy val core = (project in file("core"))
+  .settings(site.settings)
 ```
 
 ### 全局插件

--- a/src/reference/zh-cn/00-Getting-Started/11-Custom-Settings.md
+++ b/src/reference/zh-cn/00-Getting-Started/11-Custom-Settings.md
@@ -51,9 +51,9 @@ lazy val commonSettings = Seq(
   version := "0.1.0-SNAPSHOT"
 )
 
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     sampleStringTask := System.getProperty("user.home"),
     sampleIntTask := {
       val sum = 1 + 2
@@ -98,9 +98,9 @@ lazy val commonSettings = Seq(
   version := "0.1.0-SNAPSHOT"
 )
 
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     startServer := {
       println("starting...")
       Thread.sleep(500)
@@ -169,9 +169,9 @@ s: 3
 应该如何实现`stopServer`任务？清理任务的概念并不适合任务的执行模型，因为任务关心的是依赖项跟踪。最后一次操作应成为依赖其他中间任务的任务。例如`stopServer`应依赖于`sampleStringTask`，在其中`stopServer`应该是 `sampleStringTask`。
 
 ```scala
-lazy val library = (project in file("library")).
-  settings(commonSettings: _*).
-  settings(
+lazy val library = (project in file("library"))
+  .settings(
+    commonSettings,
     startServer := {
       println("starting...")
       Thread.sleep(500)

--- a/src/reference/zh-cn/00-Getting-Started/12-Organizing-Build.md
+++ b/src/reference/zh-cn/00-Getting-Started/12-Organizing-Build.md
@@ -80,9 +80,9 @@ lazy val commonSettings = Seq(
   scalaVersion := "$example_scala_version$"
 )
 
-lazy val backend = (project in file("backend")).
-  settings(commonSettings: _*).
-  settings(
+lazy val backend = (project in file("backend"))
+  .settings(
+    commonSettings,
     libraryDependencies ++= backendDeps
   )
 ```


### PR DESCRIPTION
Fixes #308

Also drop usage of "varargs expansion" (`:_*`) when calling `.settings`.