### PR TITLE
Add sbt-liquibase-slick-codegen to community plugins list

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -323,6 +323,8 @@ your plugin to the list.
     <http://flywaydb.org/getstarted/firststeps/sbt.html>
 -   sbt-liquibase (Liquibase RDBMS database migrations):
     <https://github.com/bigtoast/sbt-liquibase>
+-   sbt-liquibase-slick-codegen (Generate Slick database schema code from Liquibase changelog file):
+    <https://github.com/daniel-shuy/liquibase-slick-codegen-sbt-plugin>
 -   sbt-dbdeploy (dbdeploy, a database change management tool):
     <https://github.com/mr-ken/sbt-dbdeploy>
 -   sbt-pillar (tasks for managing Cassandra DB migrations using Pillar library):


### PR DESCRIPTION
Added sbt-liquibase-slick-codegen (a plugin to generate Slick database schema code from a Liquibase changelog file)