### PR TITLE
Make travis build verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
  - sudo add-apt-repository -y ppa:texlive-backports/ppa
  - echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
- - sudo apt-get update -qq
- - sudo apt-get install -qq sbt ruby-dev pandoc latex-cjk-all texlive-full
+ - sudo apt-get update
+ - sudo apt-get install sbt ruby-dev pandoc latex-cjk-all texlive-full
 before_script:
  - export JVM_OPTS="-Xms1024m -Xmx1024m -XX:ReservedCodeCacheSize=128m -XX:MaxPermSize=256m -Xss2m -Dfile.encoding=UTF-8"


### PR DESCRIPTION
Drop `-qq` from apt commands since Travis needs output to sense build activity and not stalling.
