### PR TITLE
Use debug log for redirect gen

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -135,7 +135,7 @@ object Docs {
 </html>
 """
     IO.write(linkFile, page, IO.utf8)
-    log.info(s"generated ${linkFile.toString} that links to $path")
+    log.debug(s"generated ${linkFile.toString} that links to $path")
     linkFile
   }
 


### PR DESCRIPTION
Do you need the output from generating redirects for your workflow or could they be silenced?  If you need a record of these, maybe it's possible to parameterize the `logLevel` to `Level.debug` for Travis or when you deploy.