### PR TITLE
Add missing import for InputTask example and fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ To push site, from sbt shell:
 > ghpagesPushSite
 ```
 
-Beward of https://github.com/sbt/sbt-ghpages/issues/25
+Beware of https://github.com/sbt/sbt-ghpages/issues/25

--- a/src/reference/02-DetailTopics/04-Tasks-and-Commands/02-Input-Tasks.md
+++ b/src/reference/02-DetailTopics/04-Tasks-and-Commands/02-Input-Tasks.md
@@ -45,6 +45,8 @@ For example, the following task prints the current Scala version and
 then echoes the arguments passed to it on their own line.
 
 ```scala
+import complete.DefaultParsers._
+
 demo := {
   // get the result of parsing
   val args: Seq[String] = spaceDelimited("<arg>").parsed


### PR DESCRIPTION
The import is needed for the first basic example to work, whether in a plugin or directly in the build.sbt. The README also had a typo. 