### PR TITLE
Adding reference to sbt-gitlab plugin

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -388,6 +388,8 @@ your plugin to the list.
     <https://github.com/ktoso/sbt-jol>
 -   sbt-hocon (operations on HOCON data against reference configuration aggregated from project dependencies):
     <https://github.com/aalleexxeeii/sbt-hocon>
+-   sbt-gitlab (SBT plugin for interacting with GitLab and GitLabCI through the available API's):
+    <https://gitlab.com/kpmeen/sbt-gitlab>
 
 #### Database plugins
 


### PR DESCRIPTION
Adds a reference to a new plugin I'm developing, that integrates with the GitLab API's. Currently it allows a user to control gitlab-ci pipelines.