### PR TITLE
Add missing reference to Appending-Values chapter

### DIFF
--- a/src/reference/00-Getting-Started/07B-Appending-Values.md
+++ b/src/reference/00-Getting-Started/07B-Appending-Values.md
@@ -2,6 +2,8 @@
 out: Appending-Values.html
 ---
 
+  [Scopes]: Scopes.html
+
 Appending values
 ----------------
 


### PR DESCRIPTION
Link to scopes in [Appending-Values](http://www.scala-sbt.org/0.13/docs/Appending-Values.html#When+settings+are+undefined) chapter is rendered as `[scope][Scopes]`, this commit fixes that.