### PR TITLE
Add sbt-updates to the list of sbt 1.0.0 plugins

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -48,3 +48,4 @@ your plugin to the list.
 - Coursier 1.0.0-RC2 <https://github.com/coursier/coursier>
 - sbt-pgp 1.1.0-M1: http://www.scala-sbt.org/sbt-pgp/
 - sbt-sonatype 2.0.0-M1: <https://github.com/xerial/sbt-sonatype>
+- sbt-updates 0.3.1: <https://travis-ci.org/rtimush/sbt-updates>


### PR DESCRIPTION
sbt-updates 0.3.1 is cross-built for sbt 1.0.0-M5 and 1.0.0-M6