### PR TITLE
Fixed sbt-updates plugin link

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -48,4 +48,4 @@ your plugin to the list.
 - Coursier 1.0.0-RC2 <https://github.com/coursier/coursier>
 - sbt-pgp 1.1.0-M1: http://www.scala-sbt.org/sbt-pgp/
 - sbt-sonatype 2.0.0-M1: <https://github.com/xerial/sbt-sonatype>
-- sbt-updates 0.3.1: <https://travis-ci.org/rtimush/sbt-updates>
+- sbt-updates 0.3.1: <https://github.com/rtimush/sbt-updates>


### PR DESCRIPTION
#366 linked to Travis CI by mistake instead of GitHub.