### PR TITLE
Remove experimental warning from testForkedParallel

### DIFF
--- a/src/reference/02-DetailTopics/02-Configuration/14-Testing.md
+++ b/src/reference/02-DetailTopics/02-Configuration/14-Testing.md
@@ -223,8 +223,8 @@ forked JVMs allowed to run at the same time by setting the limit on
 actions cannot be provided with the actual test class loader when a
 group is forked.
 
-In addition, forked tests can optionally be run in parallel.  This feature
-is still considered experimental, and may be enabled with the following setting :
+In addition, forked tests can optionally be run in parallel within the
+forked JVM(s), using the following setting:
 
 ```scala
 testForkedParallel in Test := true


### PR DESCRIPTION
The `testForkedParallel` feature is almost 4 years old, and in the time that it has existed, there has never been a confirmed bug report against it. It shouldn't be considered experimental anymore.