### PR TITLE
Fix typo in Mac install instruction (homebrew)

### DIFF
--- a/src/reference/00-Getting-Started/01-Setup/a.md
+++ b/src/reference/00-Getting-Started/01-Setup/a.md
@@ -22,7 +22,7 @@ Download [ZIP][ZIP] or [TGZ][TGZ] package, and expand it.
 #### [Homebrew](http://mxcl.github.com/homebrew/)
 
 ```
-\$ brew install sbt -devel
+\$ brew install sbt --devel
 ```
 
 #### [Macports](http://macports.org/)


### PR DESCRIPTION
Running `brew install sbt -devel` installs sbt v0.13.16, whereas `brew install sbt --devel` installs sbt v1.0.0-RC2, which probably is what was intended in the first place.