### PR TITLE
fix warnings in project/{Docs.scala, Pdf.scala}

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -47,7 +47,7 @@ object Docs {
             generateRedirect(s"../../docs/$lang/$x", output / lang / x, s.log)
           }
         }
-        output ** AllPassFilter --- output x relativeTo(output)
+        output ** AllPassFilter --- output pair relativeTo(output)
       }
     )
 
@@ -122,7 +122,7 @@ object Docs {
       generateRedirect("../Advanced-Configurations-Example.html", exp / "Advanced-Configurations-Example.html", s.log)
       generateRedirect("../Advanced-Command-Example.html", exp / "Advanced-Command-Example.html", s.log)
 
-      output ** AllPassFilter --- output x relativeTo(output)
+      output ** AllPassFilter --- output pair relativeTo(output)
     }
   )
 

--- a/project/Pdf.scala
+++ b/project/Pdf.scala
@@ -22,7 +22,7 @@ object Pdf {
 	  inConfig(config)(Seq(
         generatePdf := Pdf.makeCombinedPdf(config, pdfName).value,
         mappings in generatePdf := {
-        	generatePdf.value x relativeTo(target.value)
+        	generatePdf.value pair relativeTo(target.value)
         }
 	  ))
 


### PR DESCRIPTION
```
[warn] /home/travis/build/sbt/website/project/Docs.scala:50: method x in class PathFinder is deprecated: Use pair.
[warn]         output ** AllPassFilter --- output x relativeTo(output)
[warn]                                            ^
[warn] /home/travis/build/sbt/website/project/Docs.scala:125: method x in class PathFinder is deprecated: Use pair.
[warn]       output ** AllPassFilter --- output x relativeTo(output)
[warn]                                          ^
[warn] /home/travis/build/sbt/website/project/Pdf.scala:25: method x in class PathFinder is deprecated: Use pair.
[warn]         	generatePdf.value x relativeTo(target.value)
[warn]         	                  ^
```