### PR TITLE
Can build in Java 8 now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
     - $HOME/.ivy2/cache
 
 jdk:
-  - openjdk7
+  - openjdk8
 
 install:
   - gem install nanoc:4.0.2

--- a/README.md
+++ b/README.md
@@ -46,15 +46,6 @@ On Mac
 
 ## Usage
 
-Currently, Java 7 is required to build the site.  If you have multiple
-versions of Java installed on your system, set it to Java 7 (also
-known as version 1.7).  One method for choosing the Java version is to
-override the value of `JAVA_HOME` in the environment sbt runs.
-
-```
-$ env JAVA_HOME="$(/usr/libexec/java_home -v 1.7)" sbt
-```
-
 To make site locally, from sbt shell:
 
 ```


### PR DESCRIPTION
After #447 the site now works in Java 1.8.  Might as well update the README and the Travis build as such.  Looks like `.java-version` already was updated.