### PR TITLE
Added sbt-taglist to plugin listing

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -150,8 +150,8 @@ your plugin to the list.
 
 #### Static code analysis plugins
 
-...
-
+- sbt-taglist (Find and log TODO, FIXMEs in source files):
+    <https://github.com/johanandren/sbt-taglist>
 
 #### Code coverage plugins
 


### PR DESCRIPTION
Not quite sure about the section but "static code analysis" felt like it was the least bad fit ;)