### PR TITLE
There is no "xml to ProcessBuilder implicit conversions" exists

### DIFF
--- a/src/reference/02-DetailTopics/02-Configuration/12-Process.md
+++ b/src/reference/02-DetailTopics/02-Configuration/12-Process.md
@@ -33,15 +33,6 @@ error. You can pass a `Logger` to the `!` method to send output to the
 "find project -name *.jar" ! log
 ```
 
-Two alternative implicit conversions are from `scala.xml.Elem` or
-`List[String]` to `scala.sys.process.ProcessBuilder`. These are useful
-for constructing commands. An example of the first variant from the
-android plugin:
-
-```scala
-<x> {dxPath.absolutePath} --dex --output={classesDexPath.absolutePath} {classesMinJarPath.absolutePath}</x> !
-```
-
 If you need to set the working directory or modify the environment, call
 `scala.sys.process.Process` explicitly, passing the command sequence
 (command and argument list) or command string first and the working


### PR DESCRIPTION
sbt 0.13
- https://github.com/sbt/sbt/blob/v0.13.16/util/process/src/main/scala/sbt/Process.scala#L16-L17
- https://github.com/sbt/sbt/blob/v0.13.16/util/process/src/main/scala/sbt/Process.scala#L56-L57

scala std
- https://github.com/scala/scala/blob/v2.12.3/src/library/scala/sys/process/Process.scala