### PR TITLE
SbtExclusionRule doesn't exist anymore

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
@@ -297,19 +297,15 @@ libraryDependencies +=
 See [ModuleID](../api/sbt/ModuleID.html) for API details.
 
 In certain cases a transitive dependency should be exluded from
-all dependencies. This can be achieved by setting up `SbtExclusionRules`
+all dependencies. This can be achieved by setting up `ExclusionRules`
 in `excludeDependencies`. 
 
 ```scala
 excludeDependencies ++= Seq(
   // commons-logging is replaced by jcl-over-slf4j
-  SbtExclusionRule("commons-logging", "commons-logging")
+  ExclusionRule("commons-logging", "commons-logging")
 )
 ```
-
-Available since sbt 0.13.9.
-
-See [SbtExclusionRule](../api/sbt/SbtExclusionRule.html) for API details.
 
 ##### Download Sources
 


### PR DESCRIPTION
This update the documentation to use `ExclusionRule` instead inside `excludeDependencies`.

I removed the reference to the SBT version in which this class started as IMHO doesn't add much in 1.0.x docs but I'll be happy to put it in place again if needed.