### PR TITLE
Fix formatting of code snippet on custom tasks howto page

### DIFF
--- a/src/reference/04-Howto/13-Howto-Custom-Tasks.md
+++ b/src/reference/04-Howto/13-Howto-Custom-Tasks.md
@@ -1,16 +1,14 @@
-Define Custom Tasks 
+Define Custom Tasks
 -------------------
 
 ### Define a Task that runs tests in specific sub-projects
 
-Consider a hypothetical multi-build project with 3 subprojects. The following defines a task `myTestTask` that will 
+Consider a hypothetical multi-build project with 3 subprojects. The following defines a task `myTestTask` that will
 run the `test` Task in specific subprojects  `core` and `tools` but not `client`:
 
-```
+```scala
 lazy val core = project.in(file("./core"))
-
 lazy val tools = project.in(file("./tools"))
-
 lazy val client = project.in(file("./client"))
 
 lazy val myTestTask = TaskKey[Unit]("my-test-task")


### PR DESCRIPTION
This sets the syntax for the code snippet on the custom tasks page to the rendering.