### PR TITLE
fix compile error in Input-Tasks.md example

### DIFF
--- a/src/reference/02-DetailTopics/04-Tasks-and-Commands/02-Input-Tasks.md
+++ b/src/reference/02-DetailTopics/04-Tasks-and-Commands/02-Input-Tasks.md
@@ -84,8 +84,9 @@ get the setting values with the special `value` method:
 
 ```scala
 import complete.DefaultParsers._
+import complete.Parser
 
-val parser: Initialize[State => Parser[(String,String)]] =
+val parser: Def.Initialize[State => Parser[(String,String)]] =
 Def.setting {
   (state: State) =>
     ( token("scala" <~ Space) ~ token(scalaVersion.value) ) |


### PR DESCRIPTION
```
build.sbt:5: error: not found: type Initialize
val parser: Initialize[State => Parser[(String,String)]] =
            ^
```

```
build.sbt:5: error: not found: type Parser
val parser: Def.Initialize[State => Parser[(String,String)]] =
                                    ^
```