### PR TITLE
Recover Macro Projects shell snippets

### DIFF
--- a/src/reference/02-DetailTopics/02-Configuration/09-Macro-Projects.md
+++ b/src/reference/02-DetailTopics/02-Configuration/09-Macro-Projects.md
@@ -91,6 +91,12 @@ object Usage {
 
 This can be then be run at the console:
 
+```text
+$ sbt
+> macroSub/test:run
+scala.collection.immutable.List.apply[Int](1, 2, 3).reverse
+```
+
 Actual tests can be defined and run as usual with `macro/test`.
 
 The main project can use the macro in the same way that the tests do.
@@ -107,6 +113,12 @@ object Usage {
       println(s)
    }
 }
+```
+
+```text
+$ sbt
+> core/run
+scala.collection.immutable.List.apply[Int](6, 4, 5).sorted[Int](math.this.Ordering.Int)
 ```
 
 ### Common Interface


### PR DESCRIPTION
These were lost in the reStructuredText to Markdown conversion in
57bb93275be27eb6c2a58348204bacf1a0a5f90d.

Also update the resulting output.