### PR TITLE
Make paths absolute on 404 page

### DIFF
--- a/src/nanoc/Rules
+++ b/src/nanoc/Rules
@@ -25,11 +25,17 @@ compile '*' do
     filter :erb
     filter :redcarpet
     layout item[:layout] || 'default'
-    filter :relativize_paths, :type => :html
+    # error layout pages can be served from anywhere so must have absolute paths
+    if (item[:layout] != 'error')
+      filter :relativize_paths, :type => :html
+    end
   else
     filter :erb
     layout item[:layout] || 'default'
-    filter :relativize_paths, :type => :html
+    # error layout pages can be served from anywhere so must have absolute paths
+    if (item[:layout] != 'error')
+      filter :relativize_paths, :type => :html
+    end
   end
 end
 

--- a/src/nanoc/content/404.md
+++ b/src/nanoc/content/404.md
@@ -1,5 +1,6 @@
 ---
 title: "404: Page not found"
+layout: error
 ---
 ## Sorry we couldn't find that page
 

--- a/src/nanoc/layouts/error.html
+++ b/src/nanoc/layouts/error.html
@@ -1,0 +1,141 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>sbt - <%= @item[:title] %></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="<%= @items['/bootstrap_style/'].path %>">
+    <link rel="stylesheet" href="<%= @items['/bootstrap-theme/'].path %>">
+    <link rel="stylesheet" href="<%= @items['/stylesheet/'].path %>?v2017-09-22c">
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic" rel="stylesheet" type="text/css">
+    <link rel='shortcut icon' href="<%= @items['/favicon/'].path %>" />
+    <link rel="icon" type="image/png" sizes="32x32" href="<%= @items['/favicon-32x32/'].path %>">
+    <link rel="icon" type="image/png" sizes="96x96" href="<%= @items['/favicon-96x96/'].path %>">
+    <link rel="icon" type="image/png" sizes="16x16" href="<%= @items['/favicon-16x16/'].path %>">
+    <!-- you don't need to keep this, but it's cool for stats! -->
+    <meta name="generator" content="nanoc <%= Nanoc::VERSION %>">
+
+  </head>
+  <body class="default">
+    <header>
+        <nav>
+          <div class="container">
+            <div class="row">
+              <div class="col-md-3">
+                <div class="logo">
+                  <a href="<%= @items['/'].path %>index.html">
+                    <img src="<%= @items['/sbt-logo/'].path %>" alt="sbt">
+                  </a>
+                </div>
+              </div>
+              <div class="col-md-9">
+                <div class="nav">
+                  <a href="<%= @items['/documentation/'].path %>">Documentation</a>
+                  <a href="<%= @items['/download/'].path %>">Download</a>
+                  <a href="<%= @items['/community/'].path %>">Get Involved</a>
+                  <a id="source-code" href="https://github.com/sbt/sbt"><img src="<%= @items['/github-logo-teal/'].path %>" alt="Source code" class="social"></a>
+                  <a id="twitter" href="https://twitter.com/scala_sbt"><img src="<%= @items['/twitter-logo-teal/'].path %>" alt="sbt on Twitter" class="social"></a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </nav>
+    </header>
+
+    <div class="page-title">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <h1><%= @item[:title] %></h1>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="fw-wrapper white">
+      <div class="container content">
+        <div class="row">
+          <div class="col-md-8">
+            <div id="main">
+              <%= yield %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="fw-wrapper navy-ltr support-strip">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="support-item">
+              <div class="support-icon">
+                <svg class="svg-icon svg-icon-chat" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 97.5 85.2" enable-background="new 0 0 97.5 85.2"><path stroke="#fff" stroke-width="4.282" stroke-linecap="round" stroke-miterlimit="10" d="M27 29.5h-16.3c-4.7 0-8.6 3.9-8.6 8.6v25.7c0 4.7 3.9 8.6 8.6 8.6h2.7c.8 0 1.5.7 1.5 1.5v7.8c0 1.3 1.6 2 2.5 1l9.5-9.5c.5-.5 1.2-.8 2-.8h20.2c4.7 0 8.6-3.9 8.6-8.6v-7.8" fill="none"/><path fill="#fff" d="M85 0h-40c-6.9 0-12.5 5.6-12.5 12.5v33.4c0 2.2 1.8 4.1 4.1 4.1h29.9c.7 0 1.3.3 1.8.7l10 10c1.6 1.6 4.3.5 4.3-1.8v-6.5c0-1.4 1.1-2.5 2.5-2.5 6.9 0 12.5-5.6 12.5-12.5v-25c-.1-6.8-5.8-12.4-12.6-12.4z"/></svg>
+              </div>
+              <div class="support-detail">
+                <h2>Community Support</h2>
+                <a href="https://stackoverflow.com/questions/tagged/sbt">StackOverflow</a>
+              </div>
+            </div>
+            <div class="support-item">
+              <div class="support-icon">
+                <svg id="lightbend-icon-reverse" class="svg-icon svg-icon-lightbend-reverse" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 302 262"><title>lightbend-icon</title><g id="icon"><path d="M1,195v56a10,10,0,0,0,10,10H291a10,10,0,0,0,10-10V195a557.85,557.85,0,0,1-150,20A557.85,557.85,0,0,1,1,195Z" style="fill:#fff"/><path d="M291,1H11A10,10,0,0,0,1,11V176a539.94,539.94,0,0,0,150,21,539.94,539.94,0,0,0,150-21V11A10,10,0,0,0,291,1Z" style="fill:#fff"/></g></svg>
+              </div>
+              <div class="support-detail">
+                <h2>Commercial Support</h2>
+                <a href="https://www.lightbend.com/services/expert-support">Lightbend Subscription</a>
+                <a href="https://www.lightbend.com/services/training">Training</a>
+                <a href="https://www.lightbend.com/services/consulting">Consulting</a>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <footer>
+      <div class="container footer">
+        <div class="row">
+          <div class="col-md-8 sbt">
+            <nav>
+              <a href="<%= @items['/'].path %>index.html">
+                <img src="<%= @items['/sbt-logo-reverse/'].path %>" alt="sbt">
+              </a>
+              <a href="<%= @items['/documentation/'].path %>">Documentation</a>
+              <a href="<%= @items['/download/'].path %>">Download</a>
+              <a href="<%= @items['/community/'].path %>">Get Involved</a>
+            </nav>
+          </div>
+          <div class="col-md-4 text-right ts">
+            &copy; 2016-2017 Lightbend Inc.
+            <a href="https://www.lightbend.com">
+              <img src="<%= @items['/lightbend_reverse/'].path %>" alt="Lightbend, Inc.">
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+    <!-- Placed at the end -->
+    <script src="<%= @items['/jquery/'].path %>"></script>
+    <script src="<%= @items['/bootstrap/'].path %>"></script>
+    <script src="<%= @items['/arc/'].path %>"></script>
+    <script type="text/javascript" async>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-41449189-1', 'scala-sbt.org');
+    ga('send', 'pageview');
+    </script>
+    <script type="text/javascript" async>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-23127719-1', 'lightbend.com', {'allowLinker': true, 'name': 'tsTracker'});
+      ga('tsTracker.require', 'linker');
+      ga('tsTracker.linker:autoLink', ['lightbend.com','playframework.com','scala-lang.org','scaladays.org','spray.io','akka.io','scala-sbt.org']);
+      ga('tsTracker.send', 'pageview');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Fixes an issue where 404s are served up under the documentation or API pages had broken links & no styling.

Mentioned by @dwijnand [here](https://github.com/sbt/website/pull/497#issuecomment-332768748).