### PR TITLE
[0.13] Add outdated warning

### DIFF
--- a/src/reference/custom.css
+++ b/src/reference/custom.css
@@ -199,10 +199,34 @@ body .support-strip .row{
   font-size: 16px;
   text-decoration: none;
 }
+
 body .support-detail a:hover {
   color: #ffffff;
   text-decoration: underline;
 }
+
+/* warning */
+
+div#floaty-warning {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  z-index: 1000;
+  text-align: center;
+}
+
+div.warning {
+  background-color: #e25758; /* red */
+  color: white;
+  padding: 14px;
+}
+
+div.warning a {
+  color: white;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
 /* footer */
 footer {
   z-index: 10;

--- a/src/reference/es/layouts/footer.md
+++ b/src/reference/es/layouts/footer.md
@@ -50,3 +50,6 @@
     </div>
   </div>
 </footer>
+<script src="/assets/versions.js"></script>
+<script src="/assets/set-versions.js"></script>
+<script src="/assets/warnOldDocs.js"></script>

--- a/src/reference/ja/layouts/footer.md
+++ b/src/reference/ja/layouts/footer.md
@@ -50,3 +50,6 @@
     </div>
   </div>
 </footer>
+<script src="/assets/versions.js"></script>
+<script src="/assets/set-versions.js"></script>
+<script src="/assets/warnOldDocs.js"></script>

--- a/src/reference/layouts/footer.md
+++ b/src/reference/layouts/footer.md
@@ -52,3 +52,4 @@
 </footer>
 <script src="/assets/versions.js"></script>
 <script src="/assets/set-versions.js"></script>
+<script src="/assets/warnOldDocs.js"></script>

--- a/src/reference/zh-cn/layouts/footer.md
+++ b/src/reference/zh-cn/layouts/footer.md
@@ -50,3 +50,6 @@
     </div>
   </div>
 </footer>
+<script src="/assets/versions.js"></script>
+<script src="/assets/set-versions.js"></script>
+<script src="/assets/warnOldDocs.js"></script>


### PR DESCRIPTION
This change displays the following banner on the bottom of the 0.13 pages:

![outdated](https://user-images.githubusercontent.com/184683/31059736-8739dc70-a6d5-11e7-8313-082a118339ea.png)
