### PR TITLE
Add sbt 1.0 compatible plugins to community plugins page

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -114,6 +114,9 @@ your plugin to the list.
   directly to Heroku. <!-- 86 stars -->
 - [sbt-docker-compose](https://github.com/Tapad/sbt-docker-compose):
   launch Docker images using docker compose. <!-- 86 stars -->
+- [sbt-marathon](https://github.com/Tapad/sbt-marathon): deploy applications
+  on Apache Mesos using the [Marathon](https://mesosphere.github.io/marathon)
+  framework. <!-- 19 stars -->
 
 #### Utility and system plugins
 

--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -98,6 +98,9 @@ your plugin to the list.
   <!-- 32 stars -->
 - [sbt-github-release](https://github.com/ohnosequences/sbt-github-release): 
   publish Github releases. <!-- 22 stars -->
+- [sbt-hadoop](https://github.com/Tapad/sbt-hadoop-oss): publish artifacts
+  to the [Hadoop](https://hadoop.apache.org) Distributed File System (HDFS).
+  <!-- 6 stars -->
 - [sbt-publish-more](https://github.com/laughedelic/sbt-publish-more):
   publish artifacts to several repositories <!-- 1 star -->
 - [sbt-deploy](https://github.com/amanjpro/sbt-deploy-plugin): create

--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -157,6 +157,8 @@ your plugin to the list.
   projects. <!-- 13 stars -->
 - [sbt-jshell](https://github.com/xuwei-k/sbt-jshell): Java REPL for sbt.
   <!-- 10 stars -->
+- [sbt-check](https://github.com/jeffreyolchovy/sbt-check): compile up to,
+  and including, the typer phase. <!-- 10 stars -->
 - [sbt-tmpfs](https://github.com/cuzfrog/sbt-tmpfs): utilize tmpfs to speed
   up builds. <!-- 4 stars -->
 - [sbt-sh](https://github.com/melezov/sbt-sh): run shell commands from sbt.


### PR DESCRIPTION
Added the following plugins to the community plugins page:
- [sbt-hadoop](https://github.com/Tapad/sbt-hadoop-oss)
- [sbt-marathon](https://github.com/Tapad/sbt-marathon)
- [sbt-check](https://github.com/jeffreyolchovy/sbt-check)

Each of these supports both sbt 0.13.x and 1.0.x.

It seemed like the ordering within each plugin section was ordered by amount of Github stars (desc), so I preserved that ordering.

@eed3si9n as these also support 0.13, should I take out a PR on the 0.13.x branch as well?