### PR TITLE
Fix API links for version 1.x

### DIFF
--- a/src/reference/00-Getting-Started/05-Basic-Def.md
+++ b/src/reference/00-Getting-Started/05-Basic-Def.md
@@ -87,9 +87,9 @@ A setting expression consists of three parts:
 
 On the left-hand side, `name`, `version`, and `scalaVersion` are *keys*.
 A key is an instance of
-[`SettingKey[T]`](../api/index.html#sbt.SettingKey),
-[`TaskKey[T]`](../api/index.html#sbt.TaskKey), or
-[`InputKey[T]`](../api/index.html#sbt.InputKey) where `T` is the
+[`SettingKey[T]`](../api/sbt/SettingKey.html),
+[`TaskKey[T]`](../api/sbt/TaskKey.html), or
+[`InputKey[T]`](../api/sbt/InputKey.html) where `T` is the
 expected value type. The kinds of key are explained below.
 
 Because key `name` is typed to `SettingKey[String]`,

--- a/src/reference/00-Getting-Started/11-Custom-Settings.md
+++ b/src/reference/00-Getting-Started/11-Custom-Settings.md
@@ -94,7 +94,7 @@ write code based on the HTML library, perhaps).
 
 sbt has some utility libraries and convenience functions, in particular
 you can often use the convenient APIs in
-[IO](../api/index.html#sbt.IO\$) to manipulate files and directories.
+[IO](../api/sbt/io/IO\$.html) to manipulate files and directories.
 
 ### Execution semantics of tasks
 

--- a/src/reference/01-General-Info/90-Changes/49-ChangeSummary_0.13.0.md
+++ b/src/reference/01-General-Info/90-Changes/49-ChangeSummary_0.13.0.md
@@ -105,7 +105,7 @@ sbt 0.13.0 - 0.13.2
 -   `compileInputs` is now defined in `(Compile,compile)` instead of
     just `Compile`
 -   The result of running tests is now
-    [Tests.Output](../api/#sbt.Tests\$\$Output).
+    [Tests.Output](../api/sbt/Tests\$\$Output.html).
 
 #### Features
 

--- a/src/reference/02-DetailTopics/02-Configuration/01-Classpaths.md
+++ b/src/reference/02-DetailTopics/02-Configuration/01-Classpaths.md
@@ -17,7 +17,7 @@ In sbt 0.10 and later, classpaths now include the Scala library and
 (when declared as a dependency) the Scala compiler. Classpath-related
 settings and tasks typically provide a value of type `Classpath`. This
 is an alias for `Seq[Attributed[File]]`.
-[Attributed](../api/sbt/Attributed.html) is a type that associates
+[Attributed](../api/sbt/internal/util/Attributed.html) is a type that associates
 a heterogeneous map with each classpath entry. Currently, this allows
 sbt to associate the `Analysis` resulting from compilation with the
 corresponding classpath entry and for managed entries, the `ModuleID`

--- a/src/reference/02-DetailTopics/02-Configuration/03-Configuring-Scala.md
+++ b/src/reference/02-DetailTopics/02-Configuration/03-Configuring-Scala.md
@@ -107,8 +107,8 @@ libraryDependencies ++= Seq(
 ```
 
 In the second case, directly construct a value of type
-[ScalaInstance](../api/sbt/ScalaInstance.html), typically using a
-method in the [companion object](../api/sbt/ScalaInstance\$.html),
+[ScalaInstance](../api/sbt/internal/inc/ScalaInstance.html), typically using a
+method in the [companion object](../api/sbt/internal/inc/ScalaInstance\$.html),
 and assign it to `scalaInstance`. You will also need to add the
 `scala-library` jar to the classpath to compile and run Scala sources.
 For example,

--- a/src/reference/02-DetailTopics/02-Configuration/07-Mapping-Files.md
+++ b/src/reference/02-DetailTopics/02-Configuration/07-Mapping-Files.md
@@ -10,14 +10,14 @@ type `Seq[(File, String)]` from an input file to the path to use in the
 resulting artifact (jar). Similarly, tasks that copy files accept
 mappings of type `Seq[(File, File)]` from an input file to the
 destination file. There are some methods on
-[PathFinder](../api/sbt/PathFinder.html) and
-[Path](../api/sbt/Path\$.html) that can be useful for constructing
+[PathFinder](../api/sbt/io/PathFinder.html) and
+[Path](../api/sbt/io/Path\$.html) that can be useful for constructing
 the `Seq[(File, String)]` or `Seq[(File, File)]` sequences.
 
 A common way of making this sequence is to start with a `PathFinder` or
 `Seq[File]` (which is implicitly convertible to `PathFinder`) and then
 call the `pair` method. See the
-[PathFinder](../api/sbt/PathFinder.html) API for details, but
+[PathFinder](../api/sbt/io/PathFinder.html) API for details, but
 essentially this method accepts a function `File => Option[String]` or
 `File => Option[File]` that is used to generate mappings.
 

--- a/src/reference/02-DetailTopics/02-Configuration/10-Paths.md
+++ b/src/reference/02-DetailTopics/02-Configuration/10-Paths.md
@@ -10,10 +10,10 @@ base type used is
 [java.io.File](https://docs.oracle.com/javase/8/docs/api/java/io/File.html),
 but several methods are augmented through implicits:
 
--   [RichFile](../api/sbt/RichFile.html) adds methods to File
--   [PathFinder](../api/sbt/PathFinder.html) adds methods to File
+-   [RichFile](../api/sbt/io/RichFile.html) adds methods to File
+-   [PathFinder](../api/sbt/io/PathFinder.html) adds methods to File
     and Seq[File]
--   [Path](../api/sbt/Path\$.html) and [IO](../api/sbt/IO\$.html)
+-   [Path](../api/sbt/io/Path\$.html) and [IO](../api/sbt/io/IO\$.html)
     provide general methods related to files and I/O.
 
 ### Constructing a File

--- a/src/reference/02-DetailTopics/03-Dependency-Management/01-Artifacts.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/01-Artifacts.md
@@ -130,7 +130,7 @@ Artifact("myproject", "jdk15")
 See the
 [Ivy documentation](https://ant.apache.org/ivy/history/2.3.0/ivyfile/dependency-artifact.html)
 for more details on artifacts. See the
-[Artifact API](../api/sbt/Artifact\$.html) for combining the
+[Artifact API](../api/sbt/librarymanagement/Artifact\$.html) for combining the
 parameters above and specifying [Configurations] and extra attributes.
 
 To declare these artifacts for publishing, map them to the task that
@@ -148,7 +148,7 @@ addArtifact( Artifact("myproject", "image", "jpg"), myImageTask )
 ```
 
 `addArtifact` returns a sequence of settings (wrapped in a
-[SettingsDefinition](../api/#sbt.Init\$SettingsDefinition)). In a
+[SettingsDefinition](../api/sbt/internal/util/Init\$SettingsDefinition.html)). In a
 full build configuration, usage looks like:
 
 ```scala

--- a/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
@@ -294,7 +294,7 @@ libraryDependencies +=
   )
 ```
 
-See [ModuleID](../api/sbt/ModuleID.html) for API details.
+See [ModuleID](../api/sbt/librarymanagement/ModuleID.html) for API details.
 
 In certain cases a transitive dependency should be exluded from
 all dependencies. This can be achieved by setting up `ExclusionRules`
@@ -412,7 +412,7 @@ checksums := Seq("sha1", "md5")
 The conflict manager decides what to do when dependency resolution
 brings in different versions of the same library. By default, the latest
 revision is selected. This can be changed by setting `conflictManager`,
-which has type [ConflictManager](../api/sbt/ConflictManager.html).
+which has type [ConflictManager](../api/sbt/librarymanagement/ConflictManager.html).
 See the
 [Ivy documentation](https://ant.apache.org/ivy/history/latest-milestone/settings/conflict-managers.html)
 for details on the different conflict managers. For example, to specify

--- a/src/reference/02-DetailTopics/03-Dependency-Management/06-Resolvers.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/06-Resolvers.md
@@ -80,32 +80,32 @@ configured identically except for the name of the factory. Use
     <td>Filesystem</td>
     <td><tt>Resolver.file</tt></td>
     <td><a href="https://ant.apache.org/ivy/history/latest-milestone/resolver/filesystem.html">Ivy filesystem</a></td>
-    <td><a href="../api/sbt/Resolver\$\$file\$.html">filesystem factory</a></td>
-    <td><a href="../api/sbt/FileRepository.html">FileRepository API</a></td>
+    <td><a href="../api/sbt/librarymanagement/ResolverFunctions\$file\$.html">filesystem factory</a></td>
+    <td><a href="../api/sbt/librarymanagement/FileRepository.html">FileRepository API</a></td>
   </tr>
 
   <tr>
     <td>SFTP</td>
     <td><tt>Resolver.sftp</tt></td>
     <td><a href="https://ant.apache.org/ivy/history/latest-milestone/resolver/sftp.html">Ivy sftp</a></td>
-    <td><a href="../api/sbt/Resolver\$\$Define\$.html">sftp factory</a></td>
-    <td><a href="../api/sbt/SftpRepository.html">SftpRepository API</a></td>
+    <td><a href="../api/sbt/librarymanagement/ResolverFunctions\$sftp\$.html">sftp factory</a></td>
+    <td><a href="../api/sbt/librarymanagement/SftpRepository.html">SftpRepository API</a></td>
   </tr>
 
   <tr>
     <td>SSH</td>
     <td><tt>Resolver.ssh</tt></td>
     <td><a href="https://ant.apache.org/ivy/history/latest-milestone/resolver/ssh.html">Ivy ssh</a></td>
-    <td><a href="../api/sbt/Resolver\$\$Define\$.html">ssh factory</a></td>
-    <td><a href="../api/sbt/SshRepository.html">SshRepository API</a></td>
+    <td><a href="../api/sbt/librarymanagement/ResolverFunctions\$ssh\$.html">ssh factory</a></td>
+    <td><a href="../api/sbt/librarymanagement/SshRepository.html">SshRepository API</a></td>
   </tr>
 
   <tr>
     <td>URL</td>
     <td><tt>Resolver.url</tt></td>
     <td><a href="https://ant.apache.org/ivy/history/latest-milestone/resolver/url.html">Ivy url</a></td>
-    <td><a href="../api/sbt/Resolver\$\$url\$.html">url factory</a></td>
-    <td><a href="../api/sbt/URLRepository.html">URLRepository API</a></td>
+    <td><a href="../api/sbt/librarymanagement/ResolverFunctions\$url\$.html">url factory</a></td>
+    <td><a href="../api/sbt/librarymanagement/URLRepository.html">URLRepository API</a></td>
   </tr>
 </table>
 
@@ -216,7 +216,7 @@ resolvers += Resolver.url("my-test-repo", url)( Patterns("[organisation]/[module
 You can specify multiple patterns or patterns for the metadata and
 artifacts separately. You can also specify whether the repository should
 be Maven compatible (as defined by Ivy). See the
-[patterns API](../api/sbt/Patterns\$.html) for the methods to use.
+[patterns API](../api/sbt/librarymanagement/Patterns\$.html) for the methods to use.
 
 For filesystem and URL repositories, you can specify absolute patterns
 by omitting the base URL, passing an empty `Patterns` instance, and

--- a/src/reference/02-DetailTopics/03-Dependency-Management/07-Update-Report.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/07-Update-Report.md
@@ -6,7 +6,7 @@ Update Report
 -------------
 
 `update` and related tasks produce a value of type
-[sbt.UpdateReport](../api/sbt/UpdateReport.html) This data
+[sbt.UpdateReport](../api/sbt/librarymanagement/UpdateReport.html) This data
 structure provides information about the resolved configurations,
 modules, and artifacts. At the top level, `UpdateReport` provides
 reports of type `ConfigurationReport` for each resolved configuration. A
@@ -24,10 +24,10 @@ A typical use of `UpdateReport` is to retrieve a list of files matching
 a filter. A conversion of type `UpdateReport => RichUpdateReport`
 implicitly provides these methods for `UpdateReport`. The filters are
 defined by the
-[DependencyFilter](../api/sbt/DependencyFilter.html),
-[ConfigurationFilter](../api/sbt/ConfigurationFilter.html),
-[ModuleFilter](../api/sbt/ModuleFilter.html), and
-[ArtifactFilter](../api/sbt/ArtifactFilter.html) types. Using
+[DependencyFilter](../api/sbt/librarymanagement/DependencyFilter.html),
+[ConfigurationFilter](../api/sbt/librarymanagement/ConfigurationFilter.html),
+[ModuleFilter](../api/sbt/librarymanagement/ModuleFilter.html), and
+[ArtifactFilter](../api/sbt/librarymanagement/ArtifactFilter.html) types. Using
 these filter types, you can filter by the configuration name, the module
 organization, name, or revision, and the artifact name, type, extension,
 or classifier.

--- a/src/reference/02-DetailTopics/04-Tasks-and-Commands/01-Tasks.md
+++ b/src/reference/02-DetailTopics/04-Tasks-and-Commands/01-Tasks.md
@@ -468,7 +468,7 @@ task that provides an instance of
 [TaskStreams](../api/sbt/std/TaskStreams.html) for the defining
 task. This type provides access to named binary and text streams, named
 loggers, and a default logger. The default
-[Logger](../api/sbt/Logger.html), which is the most commonly used
+[Logger](../api/sbt/util/Logger.html), which is the most commonly used
 aspect, is obtained by the `log` method:
 
 ```scala

--- a/src/reference/02-DetailTopics/04-Tasks-and-Commands/04-Parsing-Input.md
+++ b/src/reference/02-DetailTopics/04-Tasks-and-Commands/04-Parsing-Input.md
@@ -64,7 +64,7 @@ val alwaysFail: Parser[Nothing] = failure("Invalid input.")
 ### Built-in parsers
 
 sbt comes with several built-in parsers defined in
-[sbt.complete.DefaultParsers](../api/sbt/complete/DefaultParsers\$.html).
+[sbt.complete.DefaultParsers](../api/sbt/internal/util/complete/DefaultParsers\$.html).
 Some commonly used built-in parsers are:
 
 > -   `Space`, `NotSpace`, `OptSpace`, and `OptNotSpace` for parsing
@@ -76,7 +76,7 @@ Some commonly used built-in parsers are:
 > -   `Bool` for parsing a `Boolean` value
 
 See the
-[DefaultParsers API](../api/sbt/complete/DefaultParsers\$.html) for
+[DefaultParsers API](../api/sbt/internal/util/complete/DefaultParsers\$.html) for
 details.
 
 ### Combining parsers

--- a/src/reference/02-DetailTopics/04-Tasks-and-Commands/05-Build-State.md
+++ b/src/reference/02-DetailTopics/04-Tasks-and-Commands/05-Build-State.md
@@ -128,7 +128,7 @@ val nameOpt: Option[String] = name in currentRef get structure.data
 val pkgOpts: Seq[PackageOption] = packageOptions in (currentRef, Test, packageSrc) get structure.data getOrElse Nil
 ```
 
-[BuildStructure](../api/sbt/Load\$\$BuildStructure.html) contains
+[BuildStructure](../api/sbt/internal/BuildStructure.html) contains
 information about build and project relationships. Key members are:
 
 ```scala
@@ -137,7 +137,7 @@ root: URI
 ```
 
 A `URI` identifies a build and `root` identifies the initial build
-loaded. [LoadedBuildUnit](../api/sbt/Load\$\$LoadedBuildUnit.html)
+loaded. [LoadedBuildUnit](../api/sbt/internal/LoadedBuildUnit.html)
 provides information about a single build. The key members of
 `LoadedBuildUnit` are:
 

--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/03-Plugins-Best-Practices.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/03-Plugins-Best-Practices.md
@@ -85,7 +85,7 @@ long-standing issues with plugins.
 
 ### Reuse existing keys
 
-sbt has a number of [predefined keys](../api/sbt/Keys%24.html).
+sbt has a number of [predefined keys](../api/sbt/Keys\$.html).
 Where possible, reuse them in your plugin. For instance, don't define:
 
 ```scala
@@ -120,7 +120,7 @@ obfuscateStylesheet := file("something.txt")
 
 ### Provide core feature in a plain old Scala object
 
-The core feature of sbt's `package` task, for example, is implemented in [sbt.Package](../api/#sbt.Package%24),
+The core feature of sbt's `package` task, for example, is implemented in [sbt.Package](../api/sbt/Package\$.html),
 which can be called via its `apply` method.
 This allows greater reuse of the feature from other plugins such as sbt-assembly,
 which in return implements `sbtassembly.Assembly` object to implement its core feature.

--- a/src/reference/04-Howto/01-Howto-Classpaths.md
+++ b/src/reference/04-Howto/01-Howto-Classpaths.md
@@ -146,7 +146,7 @@ val files: Seq[File] = cp.files
 
 A classpath has type `Seq[Attributed[File]]`, which means that each
 entry carries additional metadata. This metadata is in the form of an
-[AttributeMap](../api/sbt/AttributeMap.html). Useful keys for
+[AttributeMap](../api/sbt/internal/util/AttributeMap.html). Useful keys for
 entries in the map are `artifact.key`, `moduleID.key`, and `analysis`. For
 example,
 
@@ -162,7 +162,7 @@ for(entry <- classpath) yield {
 
 > **Note**: Entries may not have some or all metadata. Only entries from source
 > dependencies, such as internal projects, have an incremental
-> compilation [Analysis](../api/sbt/inc/Analysis.html). Only entries
+> compilation [Analysis](../api/sbt/internal/inc/Analysis.html). Only entries
 > for managed dependencies have an
-> [Artifact](../api/sbt/Artifact.html) and
-> [ModuleID](../api/sbt/ModuleID.html).
+> [Artifact](../api/sbt/librarymanagement/Artifact.html) and
+> [ModuleID](../api/sbt/librarymanagement/ModuleID.html).

--- a/src/reference/04-Howto/06-Howto-Logging.md
+++ b/src/reference/04-Howto/06-Howto-Logging.md
@@ -269,9 +269,9 @@ the ones provided by the old function.
 ### Log messages in a task
 
 The special task `streams` provides per-task logging and I/O via a
-[Streams](../api/#sbt.std.Streams) instance. To log, a task uses
+[Streams](../api/sbt/std/Streams.html) instance. To log, a task uses
 the `log` member from the `streams` task. Calling `log` provides
-a [Logger](../api/#sbt.Logger).
+a [Logger](../api/sbt/util/Logger.html).
 
 :
 
@@ -287,7 +287,7 @@ myTask := {
 Since settings cannot reference tasks, the special task `streams`
 cannot be used to provide logging during setting initialization.
 The recommended way is to use `sLog`. Calling `sLog.value` provides
-a [Logger](../api/#sbt.Logger).
+a [Logger](../api/sbt/util/Logger.html).
 
 ```scala
 mySetting := {

--- a/src/reference/05-Faq/00.md
+++ b/src/reference/05-Faq/00.md
@@ -160,7 +160,7 @@ or when the outputs haven't been generated yet. This support is
 primitive and subject to change.
 
 The relevant methods are two overloaded methods called
-[FileFunction.cached](../api/sbt/FileFunction\$.html). Each requires a
+[FileFunction.cached](../api/sbt/util/FileFunction\$.html). Each requires a
 directory in which to store cached data. Sample usage is:
 
 ```scala
@@ -184,10 +184,10 @@ the input tracking style is `FilesInfo.lastModified`, based on a file's
 last modified time, and the output tracking style is `FilesInfo.exists`,
 based only on whether the file exists. The other available style is
 `FilesInfo.hash`, which tracks a file based on a hash of its contents.
-See the [FilesInfo API](../api/sbt/FilesInfo\$.html) for details.
+See the [FilesInfo API](../api/sbt/util/FilesInfo\$.html) for details.
 
 A more advanced version of `FileFunction.cached` passes a data structure
-of type [ChangeReport](../api/sbt/ChangeReport.html) describing the
+of type [ChangeReport](../api/sbt/util/ChangeReport.html) describing the
 changes to input and output files since the last evaluation. This
 version of `cached` also expects the set of files generated as output to
 be the result of the evaluated function.

--- a/src/reference/90-Developers-Guide/10-DevGuide-Notes/02-Settings-Core.md
+++ b/src/reference/90-Developers-Guide/10-DevGuide-Notes/02-Settings-Core.md
@@ -2,7 +2,7 @@
 out: Settings-Core.html
 ---
 
-  [Sdocs-Global]: ../api/sbt/Global\$.html
+  [Sdocs-Zero]: ../api/sbt/Zero\$.html
   [Sdocs-This]: ../api/sbt/This\$.html
   [Sdocs-Select]: ../api/sbt/Select.html
 
@@ -90,7 +90,7 @@ object SettingsExample extends Init[Scope]
 This part shows how to use the system we just defined. The end result is
 a `Settings[Scope]` value. This type is basically a mapping
 `Scope -> AttributeKey[T] -> Option[T]`. See the
-[Settings API documentation](../api/sbt/Settings.html) for
+[Settings API documentation](../api/sbt/internal/util/Settings.html) for
 details.
 
 `SettingsUsage.scala`:
@@ -171,12 +171,12 @@ sbt defines a more complicated scope than the one shown here for the
 standard usage of settings in a build. This scope has four components:
 the project axis, the configuration axis, the task axis, and the extra
 axis. Each component may be 
-[Global][Sdocs-Global] (no specific value),
+[Zero][Sdocs-Zero] (no specific value),
 [This][Sdocs-This]
 (current context), or
 [Select][Sdocs-Select] (containing a specific value). sbt
 resolves `This_` to either
-[Global][Sdocs-Global] or
+[Zero][Sdocs-Zero] or
 [Select][Sdocs-Select]
 depending on the context.
 
@@ -185,7 +185,7 @@ For example, in a project, a
 [Select][Sdocs-Select] referring to the defining project. All other axes that are
 [This][Sdocs-This] are
 translated to
-[Global][Sdocs-Global]. Functions like `inConfig` and `inTask` transform
+[Zero][Sdocs-Zero]. Functions like `inConfig` and `inTask` transform
 `This` into a
 [Select][Sdocs-Select] for a specific value. For example,
 `inConfig(Compile)(someSettings)` translates the configuration axis for

--- a/src/reference/90-Developers-Guide/10-DevGuide-Notes/04-Build-Loaders.md
+++ b/src/reference/90-Developers-Guide/10-DevGuide-Notes/04-Build-Loaders.md
@@ -52,8 +52,8 @@ object Demo extends Build {
 
 Relevant API documentation for custom resolvers:
 
--   [ResolveInfo](../api/index.html#sbt.BuildLoader\$\$ResolveInfo)
--   [BuildLoader](../api/sbt/BuildLoader\$.html)
+-   [ResolveInfo](../api/sbt/internal/BuildLoader\$\$ResolveInfo.html)
+-   [BuildLoader](../api/sbt/internal/BuildLoader\$.html)
 
 #### Full Example
 
@@ -139,9 +139,9 @@ object Demo extends Build {
 
 Relevant API documentation for custom builders:
 
--   [BuildInfo](../api/sbt/BuildLoader\$\$BuildInfo.html)
--   [BuildLoader](../api/sbt/BuildLoader\$.html)
--   [BuildUnit](../api/index.html#sbt.Load\$\$BuildUnit)
+-   [BuildInfo](../api/sbt/internal/BuildLoader\$\$BuildInfo.html)
+-   [BuildLoader](../api/sbt/internal/BuildLoader\$.html)
+-   [BuildUnit](../api/sbt/internal/BuildUnit.html)
 
 #### Example
 
@@ -216,9 +216,9 @@ object Demo extends Build {
 
 Relevant API documentation for custom transformers:
 
--   [TransformInfo](../api/index.html#sbt.BuildLoader\$\$TransformInfo)
--   [BuildLoader](../api/sbt/BuildLoader\$.html)
--   [BuildUnit](../api/index.html#sbt.Load\$\$BuildUnit)
+-   [TransformInfo](../api/sbt/internal/BuildLoader\$\$TransformInfo.html)
+-   [BuildLoader](../api/sbt/internal/BuildLoader\$.html)
+-   [BuildUnit](../api/sbt/internal/BuildUnit.html)
 
 ##### Manipulating Project Dependencies in Settings
 
@@ -238,7 +238,7 @@ Build or referenced as the argument to `Project.aggregate` or
 ### The BuildDependencies type
 
 The type of the `buildDependencies` setting is
-[BuildDependencies](../api/sbt/BuildDependencies.html).
+[BuildDependencies](../api/sbt/internal/BuildDependencies.html).
 `BuildDependencies` provides mappings from a project to its aggregate or
 classpath dependencies. For classpath dependencies, a dependency has
 type `ClasspathDep[ProjectRef]`, which combines a `ProjectRef` with a

--- a/src/reference/ja/00-Getting-Started/05-Basic-Def.md
+++ b/src/reference/ja/00-Getting-Started/05-Basic-Def.md
@@ -83,9 +83,9 @@ build.sbt DSL を詳しくみてみよう:<br>
 
 左辺値の `name`、`version`、および `scalaVersion` は**キー**である。
 キーは
-[`SettingKey[T]`](../api/index.html#sbt.SettingKey)、
-[`TaskKey[T]`](../api/index.html#sbt.TaskKey)、もしくは
-[`InputKey[T]`]((../api/index.html#sbt.InputKey)) のインスタンスで、
+[`SettingKey[T]`](../api/sbt/SettingKey.html)、
+[`TaskKey[T]`](../api/sbt/TaskKey.html)、もしくは
+[`InputKey[T]`]((../api/sbt/InputKey.html)) のインスタンスで、
 `T` はその値の型である。キーの種類に関しては後述する。
 
 `name` キーは `SettingKey[String]` に型付けされているため、

--- a/src/reference/ja/00-Getting-Started/11-Custom-Settings.md
+++ b/src/reference/ja/00-Getting-Started/11-Custom-Settings.md
@@ -11,7 +11,7 @@ out: Custom-Settings.html
   [Tasks]: ../../docs/Tasks.html
   [Keys]: ../../sxr/sbt/Keys.scala.html
   [Defaults]: ../../sxr/sbt/Defaults.scala.html
-  [Scaladocs-IO]: ../api/index.html#sbt.IO\$
+  [Scaladocs-IO]: ../api/sbt/io/IO\$.html
 
 カスタムセッティングとタスク
 ------------------------

--- a/src/reference/zh-cn/00-Getting-Started/11-Custom-Settings.md
+++ b/src/reference/zh-cn/00-Getting-Started/11-Custom-Settings.md
@@ -67,7 +67,7 @@ lazy val library = (project in file("library"))
 
 有关任务实现最困难的部分往往不是 sbt 专用；任务只是 Scala 代码。困难的部分可能是写你的任务体，即做什么，或者说你正在试图做的。例如，你要格式化 HTML，在这种情况下，你可能需要使用一个 HTML 库（也许你将[为构建定义添加一个库的依赖][Using-Plugins]来编写基于 HTML 库代码）。
 
-sbt 具有一些实用工具库和方便的函数，特别是可以经常使用 API 中的 [IO](../../api/index.html#sbt.IO\$) 来操作文件和目录。
+sbt 具有一些实用工具库和方便的函数，特别是可以经常使用 API 中的 [IO](../../api/sbt/io/IO\$.html) 来操作文件和目录。
 
 ### 任务的执行语义
 


### PR DESCRIPTION
I've fixed almost everything I've found (I hope so). 

Only few places left which I don't know how to fix:
- in `src/reference/02-DetailTopics/02-Configuration/14-Testing.md` there is text:

  ```
  Test frameworks report status and results to test reporters. You can
  create a new test reporter by implementing either
  [TestReportListener](../api/sbt/TestReportListener.html) or
  [TestsListener](../api/sbt/TestsListener.html).
  ```

  Such classes exist in [`testing.sbt`](https://github.com/sbt/sbt/tree/v1.0.2/testing/src/main/scala/sbt) but not in main `sbt` so not present in API docs.

- in `src/reference/90-Developers-Guide/10-DevGuide-Notes/05-Command-Line-Applications.md`: 

  ```
  The application itself is defined by implementing
  [xsbti.AppMain](../api/xsbti/AppMain.html). 
  ```

  I see such class in code but don't see in [API reference](http://www.scala-sbt.org/1.0.2/api/xsbti/index.html).