### PR TITLE
xsbti.compile.IncOptions does not have copy method

### DIFF
--- a/src/reference/02-DetailTopics/01-Using-sbt/07-Incremental-Recompilation.md
+++ b/src/reference/02-DetailTopics/01-Using-sbt/07-Incremental-Recompilation.md
@@ -660,7 +660,7 @@ curl -O https://java-diff-utils.googlecode.com/files/diffutils-1.2.1.jar
 sbt -Dsbt.extraClasspath=diffutils-1.2.1.jar
 [info] Loading project definition from /Users/grek/tmp/sbt-013/project
 [info] Set current project to sbt-013 (in build file:/Users/grek/tmp/sbt-013/)
-> set incOptions := incOptions.value.copy(apiDebug = true)
+> set incOptions := incOptions.value.withApiDebug(true)
 [info] Defining *:incOptions
 [info] The new value will be used by compile:incCompileSetup, test:incCompileSetup
 [info] Reapplying settings...


### PR DESCRIPTION
https://github.com/sbt/zinc/blob/v1.0.3/internal/compiler-interface/src/main/contraband-java/xsbti/compile/IncOptions.java#L225

```
sample-project > set incOptions := incOptions.value.copy(apiDebug = true)
<set>:1: error: value copy is not a member of xsbti.compile.IncOptions
incOptions := incOptions.value.copy(apiDebug = true)
                               ^
<set>:1: error: not found: value apiDebug
incOptions := incOptions.value.copy(apiDebug = true)
                                    ^
[error] Type error in expression
```