### PR TITLE
use streams.value.cacheDirectory

### DIFF
--- a/src/reference/05-Faq/00.md
+++ b/src/reference/05-Faq/00.md
@@ -170,7 +170,7 @@ myTask := {
   // wraps a function taskImpl in an uptodate check
   //   taskImpl takes the input files, the output directory,
   //   generates the output files and returns the set of generated files
-  val cachedFun = FileFunction.cached(cacheDirectory.value / "my-task") { (in: Set[File]) =>
+  val cachedFun = FileFunction.cached(streams.value.cacheDirectory / "my-task") { (in: Set[File]) =>
     taskImpl(in, target.value) : Set[File]
   }
   // Applies the cached function to the inputs files


### PR DESCRIPTION
`sbt.Keys.cacheDirectory` removed

https://github.com/sbt/sbt/commit/a0193d28ea1bf25824bc41b1e08ba128cd9041f3#diff-46751185767542b1d052bc42435916bdL152