### PR TITLE
let set-versions.js and versions.js sync

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -265,6 +265,8 @@ object Docs {
                    List(
                      repo / "assets" / "favicon.ico",
                      repo / "assets" / "stylesheet.css",
+                     repo / "assets" / "set-versions.js",
+                     repo / "assets" / "versions.js",
                    ),
                    git,
                    s)

--- a/src/nanoc/content/versions.js
+++ b/src/nanoc/content/versions.js
@@ -1,1 +1,1 @@
-var availableDocumentationVersions = ['0.13', '0.12.4', '0.7.7']
+var availableDocumentationVersions = ['1.x', '0.13', '0.12.4', '0.7.7']


### PR DESCRIPTION
@Philippus updated `set-versions.js` in https://github.com/sbt/website/pull/541, but that didn't seem to deploy: https://github.com/sbt/sbt.github.com/blob/7cbb54a55a2ab953a555d2c5d29903fa990ec810/assets/set-versions.js

This attempts to fix the syncing.
