### PR TITLE
fix Task-Graph.md example

### DIFF
--- a/src/reference/00-Getting-Started/06-Task-Graph.md
+++ b/src/reference/00-Getting-Started/06-Task-Graph.md
@@ -266,8 +266,8 @@ Here's how it should look on the sbt shell:
 [info] * -deprecation
 [info] * -unchecked
 [success] Total time: 0 s, completed Jan 2, 2017 11:44:44 PM
-> ++2.11.8
-[info] Setting version to 2.11.8
+> ++2.11.8!
+[info] Forcing Scala version to 2.11.8 on all projects.
 [info] Reapplying settings...
 [info] Set current project to Hello (in build file:/xxx/)
 > show scalacOptions

--- a/src/reference/ja/00-Getting-Started/06-Task-Graph.md
+++ b/src/reference/ja/00-Getting-Started/06-Task-Graph.md
@@ -256,8 +256,8 @@ sbt シェルで試すとこうなるはずだ:
 [info] * -deprecation
 [info] * -unchecked
 [success] Total time: 0 s, completed Jan 2, 2017 11:44:44 PM
-> ++2.11.8
-[info] Setting version to 2.11.8
+> ++2.11.8!
+[info] Forcing Scala version to 2.11.8 on all projects.
 [info] Reapplying settings...
 [info] Set current project to Hello (in build file:/xxx/)
 > show scalacOptions


### PR DESCRIPTION
without `!` ↓ 😕 

```
> ++2.11.8
[info] Setting Scala version to 2.11.8 on 0 projects.
[info] Excluded 1 projects, run ++ 2.11.8 -v for more details.
[info] Reapplying settings...
```

> The behaviour of ++ is changed so that it only updates the Scala version of projects that support that Scala version, but the Scala version can be post fixed with ! to force it to change for all projects.

- http://www.scala-sbt.org/1.x/docs/sbt-1.0-Release-Notes.html
- https://github.com/sbt/sbt/pull/2613