### PR TITLE
Update typo in Customizing paths page

### DIFF
--- a/src/reference/04-Howto/02-Howto-Customizing-Paths.md
+++ b/src/reference/04-Howto/02-Howto-Customizing-Paths.md
@@ -184,16 +184,16 @@ exclusion, the following also ignores files containing `impl` in their
 name,
 
 ```scala
-excludeFilter in unmanagedSources := HiddenFileFilter || "*impl*"
+excludeFilter in unmanagedResources := HiddenFileFilter || "*impl*"
 ```
 
 To have different filters for main and test libraries, configure
 `Compile` and `Test` separately:
 
 ```scala
-includeFilter in (Compile, unmanagedSources) := "*.txt"
+includeFilter in (Compile, unmanagedResources) := "*.txt"
 
-includeFilter in (Test, unmanagedSources) := "*.html"
+includeFilter in (Test, unmanagedResources) := "*.html"
 ```
 
 > **Note**: By default, sbt includes all files that are not hidden.


### PR DESCRIPTION
Hi

I'm a beginner for contribution. I've just seen something may be incorrect in `Customizing paths` page. Under `Include/exclude files in the resource directory` section, the example refers to `unmanagedSources` instead of `unmanagedResources`.

Please have a check.