### PR TITLE
fix compile error. use "pair" instead of "x"

### DIFF
--- a/src/reference/05-Faq/00.md
+++ b/src/reference/05-Faq/00.md
@@ -138,7 +138,7 @@ mappings in (Compile, packageSrc) ++= {
   import Path.{flat, relativeTo}
   val base = (sourceManaged in Compile).value
   val srcs = (managedSources in Compile).value
-  srcs x (relativeTo(base) | flat)
+  srcs pair (relativeTo(base) | flat)
 }
 ```
 


### PR DESCRIPTION
- https://github.com/sbt/sbt/blob/v0.13.16/util/io/src/main/scala/sbt/Path.scala#L127-L139
- https://github.com/sbt/io/blob/v1.1.3/io/src/main/scala/sbt/io/Path.scala#L358
- https://github.com/sbt/io/commit/3ba73c64ccb29c7cd3561d66d117633390b53d23#diff-792f2b65f0f975a01bf41d270f5f023bL138