### PR TITLE
tweak wording on landing page

### DIFF
--- a/src/nanoc/layouts/landing.html
+++ b/src/nanoc/layouts/landing.html
@@ -48,7 +48,7 @@
               <div id="main" class="text-center">
                 <h1>The interactive build tool</h1>
                 <span class="statement">
-                Use Scala to define your tasks. Then run them in parallel from the shell.
+                Define your tasks in Scala. Run them in parallel from sbt's interactive shell.
                 </span><br><br>
                 <a href="download.html" class="btn" role="button">Download</a>
               </div>


### PR DESCRIPTION
"the shell" reads as a reference to the Unix shell. I think this
wording is a little clearer