### PR TITLE
restore Full-Def.md

### DIFF
--- a/src/reference/00-Getting-Started/14-Full-Def.md
+++ b/src/reference/00-Getting-Started/14-Full-Def.md
@@ -1,0 +1,5 @@
+---
+out: Full-Def.html
+---
+
+See [migrate to build.sbt](Migrating-from-sbt-013x.html#Migrating+from+the+Build+trait)


### PR DESCRIPTION
some pages still reference `Full-Def.html`

```
git grep "Full-Def" -- src/reference/
src/reference/00-Getting-Started/05-Basic-Def.md:  [Full-Def]: Full-Def.html
src/reference/01-General-Info/90-Changes/90-Older-Changes.md:  [Full-Def]: Full-Def.html
src/reference/01-General-Info/90-Changes/90-Older-Changes.md:    [.scala build defnition][Full-Def] and [.sbt build definition][Basic-Def].
src/reference/01-General-Info/90-Changes/90-Older-Changes.md:-   New multiple project support: [.scala build defnition][Full-Def]
src/reference/02-DetailTopics/01-Using-sbt/01-Command-Line-Reference.md:  [Full-Def]: Full-Def.html
src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md:  [Full-Def]: Full-Def.html
src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md:    [.scala build definition][Full-Def] for details on
src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md:  [Full-Def]: Full-Def.html
src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md:[.scala file][Full-Def].
src/reference/02-DetailTopics/04-Tasks-and-Commands/01-Tasks.md:  [Full-Def]: Full-Def.html
src/reference/02-DetailTopics/04-Tasks-and-Commands/01-Tasks.md:[.scala build definition][Full-Def]).
src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/02-Plugins.md:  [Full-Def]: Full-Def.html
src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/02-Plugins.md:   [.scala build definition][Full-Def].
src/reference/04-Howto/12-Howto-Triggered.md:  [Full-Def]: Full-Def.html
src/reference/04-Howto/12-Howto-Triggered.md:    [.scala build definition][Full-Def] for details on inter-project
src/reference/06-Name-Index.md:  [Full-Def]: Full-Def.html
src/reference/06-Name-Index.md:    once. The types in a [.scala build definition][Full-Def] always use just a
src/reference/06-Name-Index.md:    [.scala build definition][Full-Def].
```