### PR TITLE
Use code block for the content for .credentials

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
@@ -80,10 +80,12 @@ In case you need to define credentials to connect to your proxy repository, defi
 
 with file contents
 
+```
   realm=My Nexus Repository Manager
   host=my.artifact.repo.net
   user=admin
   password=admin123
+```
 
 #### Launcher Script
 


### PR DESCRIPTION
The content for the `.credentials` file is currently rendered in one line.

