### PR TITLE
Add redirect for Full-Def.html

### DIFF
--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -101,6 +101,8 @@ object Docs {
       generateRedirect("../Migrating-from-sbt-0.7.x.html",
                        dt / "Migrating-from-sbt-0.7.x-to-0.10.x.html",
                        s.log)
+      generateRedirect("Migrating-from-sbt-013x.html#Migrating+from+the+Build+trait",
+                       output / "Full-Def.html", s.log)
       generateRedirect("../Incremental-Recompilation.html",
                        dt / "Understanding-incremental-recompilation.html",
                        s.log)

--- a/src/reference/00-Getting-Started/14-Full-Def.md
+++ b/src/reference/00-Getting-Started/14-Full-Def.md
@@ -1,5 +1,0 @@
----
-out: Full-Def.html
----
-
-See [migrate to build.sbt](Migrating-from-sbt-013x.html#Migrating+from+the+Build+trait)


### PR DESCRIPTION
I'm not sure why this was done this way in #632.

The way this renders is confusing for me.  The link barely shows up below the page header/masthead.

![redirect link in masthead](https://user-images.githubusercontent.com/358615/38198604-7fca254c-365b-11e8-9ada-29f126e2d169.png)