### PR TITLE
Explain how to prevent the project from being published

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/05-Publishing.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/05-Publishing.md
@@ -165,3 +165,7 @@ version cached, it will not check the local repository for updates,
 unless the version number matches a
 [changing pattern](https://ant.apache.org/ivy/history/2.3.0/concept.html#change),
 and `SNAPSHOT` is one such pattern.
+
+### Skipping Publishing
+
+To avoid publishing a project, add `skip in publish := true` to its settings. `false` is the default value. Common use case is to prevent publishing of the root project.


### PR DESCRIPTION
When my project was using sbt 0.13.15 I had this in my `root` project settings to prevent it from being published: `publish := {}, publishLocal := {}`.

After upgrading my project to 1.1.4 I needed to replace these with `skip in publish`. However, this is not documented anywhere AFAIK, so I had to find it out the hard way.

My knowledge of these settings is limited to what I could infer from https://github.com/sbt/sbt/issues/3136, which is why the text I'm submitting here is not very detailed, but I think it's still better than nothing.