### PR TITLE
Fix dollar escaping in proxy docs

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
@@ -76,7 +76,7 @@ This repositories file is all that's required to use a proxy repository.  These 
 
 In case you need to define credentials to connect to your proxy repository, define an environment variable `SBT_CREDENTIALS` that points to the file containing your credentials:
 
-    export SBT_CREDENTIALS="$HOME/.ivy2/.credentials"
+    export SBT_CREDENTIALS="\$HOME/.ivy2/.credentials"
 
 with file contents
 


### PR DESCRIPTION
revert a change in #657

this caused a large part of the proxy docs to be truncated: https://github.com/sbt/sbt.github.com/compare/09800bb099...7900bf9bbc#diff-2be691dcf0c8ac9d135ab75e631a215e

see the image: https://user-images.githubusercontent.com/344610/39094136-c76db8ce-4622-11e8-8d9a-7747f41a9b10.png

/cc @rbonvall