### PR TITLE
Add sbt-trace to the plugins list

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -297,7 +297,9 @@ your plugin to the list.
     <https://github.com/sksamuel/sbt-versions>
 -   sbt-bobby (Prevents outdated dependencies from being used by your project):
     <https://github.com/hmrc/sbt-bobby>
-
+-   sbt-trace (Finds traces of the client or library usage in other projects):
+    <https://github.com/delprks/sbt-trace>
+    
 #### Build interoperability plugins
 
 -   ant4sbt:


### PR DESCRIPTION
Please add sbt-trace to the plugins list.

Repository: https://github.com/delprks/sbt-trace
Website: https://delprks.com/sbt-trace/
