### PR TITLE
Adds cookie banner to site

### DIFF
--- a/src/nanoc/content/cookie.md
+++ b/src/nanoc/content/cookie.md
@@ -1,0 +1,11 @@
+---
+title: Cookie
+---
+
+<h1>Your Privacy</h1>
+<p>When you visit any web site, it may store or retrieve information on your browser, mostly in the form of cookies. This information might be about you, your preferences or your device and is mostly used to make the site work as you expect it to. The information does not usually directly identify you, but it can give you a more personalised web experience.</p>
+<p>Because we respect your right to privacy, you <a class="optanon-toggle-display">can choose</a> not to allow some types of cookies. Below is a list of the cookies that get set on the scala-sbt.org domain. Blocking some types of cookies may impact your experience of the site and the services we are able to offer.</p>
+<p><a class="optanon-toggle-display btn">COOKIE SETTINGS</a></p>
+<br><hr><br>
+<h1>Cookie Listing</h1>
+<div id="optanon-cookie-policy"></div>

--- a/src/nanoc/content/stylesheet.css
+++ b/src/nanoc/content/stylesheet.css
@@ -320,5 +320,121 @@ footer .sbt a {
 footer .sbt img {
   height: 20px;
 }
+footer p.legal {
+  font-size: 11px;
+  margin: 2rem 0;
+}
+footer p.legal a {
+  font-size: 11px;
+  margin-right: 0;
+  cursor: pointer;
+}
+
+/*oneTrust cookie*/
+
+body .optanon-alert-box-wrapper .optanon-alert-box-bottom-top {
+    height: 20px
+}
+
+body .optanon-alert-box-wrapper .optanon-alert-box-bottom-padding {
+    padding-bottom: 20px
+}
+
+.lightbend-privacy-cookie-footer {
+    padding: 1rem 0 1rem 0;
+    color: white;
+    vertical-align: middle
+}
+
+.lightbend-privacy-cookie-footer p {
+    font-size: 0.875rem;
+    vertical-align: middle
+}
+
+.lightbend-privacy-cookie-footer .optanon-show-settings-wrapper {
+    display: inline-block;
+    vertical-align: middle
+}
+
+.optanon-cookie-policy-group {
+    padding-top: 4rem
+}
+
+.optanon-cookie-policy-group:first-child {
+    padding-top: 0
+}
+
+.optanon-cookie-policy-group-name {
+    font-weight: 700;
+    margin-bottom: 0.5rem
+}
+
+.optanon-cookie-policy-subgroup-table-column-header {
+    font-weight: 700
+}
+
+.cookie-warning {
+    background: #6cc04a;
+    display: inline-block;
+    margin: 1rem 0;
+    padding: 1rem;
+    font-weight: 700;
+    border-radius: 3px;
+    text-align: center
+}
+
+.cookie-warning p {
+    color: white !important;
+    font-size: 1rem !important;
+    margin: 0
+}
+
+.cookie-warning p>a {
+    border: 1px solid white;
+    color: white;
+    display: inline-block;
+    padding: .25rem .5rem;
+    text-decoration: none;
+    margin: .25rem 1rem;
+    cursor: pointer
+}
+
+.cookie-warning p>a:hover {
+    background: rgba(255, 255, 255, 0.6);
+    color: #6cc04a
+}
+
+.cookie-warning small {
+    color: white !important;
+    font-size: .875rem !important
+}
+
+.flex-video {
+    background-color: #ebeef0;
+    text-align: center
+}
+
+.flex-video .cookie-warning {
+    background: transparent;
+    padding: .5rem 2rem;
+    margin: 2rem auto 0 auto
+}
+
+.flex-video .cookie-warning p {
+    color: #15A9CE !important
+}
+
+.flex-video .cookie-warning p>a {
+    display: block;
+    margin: 1rem auto;
+    max-width: 300px;
+    border: 1px solid #15A9CE;
+    color: #15A9CE
+}
+
+.flex-video .cookie-warning p>a:hover {
+    background: #107F9B;
+    color: white
+}
 
 /* test */

--- a/src/nanoc/layouts/default.html
+++ b/src/nanoc/layouts/default.html
@@ -15,6 +15,15 @@
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>">
 
+    <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) start -->
+    <script src="https://optanon.blob.core.windows.net/consent/d759c5db-6821-46e0-a988-6bc699efb74e.js" type="text/javascript" charset="UTF-8"></script>
+    <script type="text/javascript">
+      function OptanonWrapper() { 
+        //callback when OneTrust is loaded and ready
+      }
+    </script>
+    <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) end -->
+
   </head>
   <body class="default">
     <header>
@@ -106,9 +115,16 @@
               <a href="<%= @items['/download/'].path %>">Download</a>
               <a href="<%= @items['/community/'].path %>">Get Involved</a>
             </nav>
+            <p class="legal">
+              &copy; 2016-2018 Lightbend, Inc. |
+              <a href="https://www.lightbend.com/legal/licenses" target="_blank">Licenses</a> | 
+              <a href="https://www.lightbend.com/legal/terms" target="_blank">Terms</a> | 
+              <a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> | 
+              <a href="<%= @items['/cookie/'].path %>">Cookie Listing</a> | 
+              <a class="optanon-toggle-display">Cookie Settings</a>
+            </p>
           </div>
           <div class="col-md-4 text-right ts">
-            &copy; 2016-2017 Lightbend Inc.
             <a href="https://www.lightbend.com">
               <img src="<%= @items['/lightbend_reverse/'].path %>" alt="Lightbend, Inc.">
             </a>
@@ -120,7 +136,7 @@
     <script src="<%= @items['/jquery/'].path %>"></script>
     <script src="<%= @items['/bootstrap/'].path %>"></script>
     <script src="<%= @items['/arc/'].path %>"></script>
-    <script type="text/javascript" async>
+    <script type="text/plain" class="optanon-category-2" async>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -128,7 +144,7 @@
     ga('create', 'UA-41449189-1', 'scala-sbt.org');
     ga('send', 'pageview');
     </script>
-    <script type="text/javascript" async>
+    <script type="text/plain" class="optanon-category-2" async>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/src/nanoc/layouts/error.html
+++ b/src/nanoc/layouts/error.html
@@ -15,6 +15,15 @@
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>">
 
+    <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) start -->
+    <script src="https://optanon.blob.core.windows.net/consent/d759c5db-6821-46e0-a988-6bc699efb74e.js" type="text/javascript" charset="UTF-8"></script>
+    <script type="text/javascript">
+      function OptanonWrapper() { 
+        //callback when OneTrust is loaded and ready
+      }
+    </script>
+    <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) end -->
+
   </head>
   <body class="default">
     <header>
@@ -106,9 +115,16 @@
               <a href="<%= @items['/download/'].path %>">Download</a>
               <a href="<%= @items['/community/'].path %>">Get Involved</a>
             </nav>
+            <p class="legal">
+              &copy; 2016-2018 Lightbend, Inc. |
+              <a href="https://www.lightbend.com/legal/licenses" target="_blank">Licenses</a> | 
+              <a href="https://www.lightbend.com/legal/terms" target="_blank">Terms</a> | 
+              <a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> | 
+              <a href="<%= @items['/cookie/'].path %>">Cookie Listing</a> | 
+              <a class="optanon-toggle-display">Cookie Settings</a>
+            </p>
           </div>
           <div class="col-md-4 text-right ts">
-            &copy; 2016-2017 Lightbend Inc.
             <a href="https://www.lightbend.com">
               <img src="<%= @items['/lightbend_reverse/'].path %>" alt="Lightbend, Inc.">
             </a>
@@ -120,7 +136,7 @@
     <script src="<%= @items['/jquery/'].path %>"></script>
     <script src="<%= @items['/bootstrap/'].path %>"></script>
     <script src="<%= @items['/arc/'].path %>"></script>
-    <script type="text/javascript" async>
+    <script type="text/plain" class="optanon-category-2" async>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -128,7 +144,7 @@
     ga('create', 'UA-41449189-1', 'scala-sbt.org');
     ga('send', 'pageview');
     </script>
-    <script type="text/javascript" async>
+    <script type="text/plain" class="optanon-category-2" async>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/src/nanoc/layouts/landing.html
+++ b/src/nanoc/layouts/landing.html
@@ -15,6 +15,16 @@
     <!-- you don't need to keep this, but it's cool for stats! -->
     <meta name="generator" content="nanoc <%= Nanoc::VERSION %>">
     <meta name="google-site-verification" content="I28z-8Rg5JifsOR9NpTD9C9dFYutH_Dz8QWOHUDs6lg">
+
+    <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) start -->
+    <script src="https://optanon.blob.core.windows.net/consent/d759c5db-6821-46e0-a988-6bc699efb74e.js" type="text/javascript" charset="UTF-8"></script>
+    <script type="text/javascript">
+      function OptanonWrapper() { 
+        //callback when OneTrust is loaded and ready
+      }
+    </script>
+    <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) end -->
+    
   </head>
   <body class="landing">
     <header>
@@ -111,9 +121,16 @@
               <a href="<%= @items['/download/'].path %>">Download</a>
               <a href="<%= @items['/community/'].path %>">Get Involved</a>
             </nav>
+            <p class="legal">
+              &copy; 2016-2018 Lightbend, Inc. |
+              <a href="https://www.lightbend.com/legal/licenses" target="_blank">Licenses</a> | 
+              <a href="https://www.lightbend.com/legal/terms" target="_blank">Terms</a> | 
+              <a href="https://www.lightbend.com/legal/privacy" target="_blank">Privacy Policy</a> | 
+              <a href="<%= @items['/cookie/'].path %>">Cookie Listing</a> | 
+              <a class="optanon-toggle-display">Cookie Settings</a>
+            </p>
           </div>
           <div class="col-md-4 text-right ts">
-            &copy; 2016-2017 Lightbend Inc.
             <a href="https://www.lightbend.com">
               <img src="<%= @items['/lightbend_reverse/'].path %>" alt="Lightbend, Inc.">
             </a>
@@ -125,7 +142,7 @@
     <!-- Placed at the end -->
     <script src="<%= @items['/jquery/'].path %>" type="text/javascript"></script>
     <script src="<%= @items['/bootstrap/'].path %>" type="text/javascript"></script>
-    <script type="text/javascript" async>
+    <script type="text/plain" class="optanon-category-2" async>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -133,7 +150,7 @@
     ga('create', 'UA-41449189-1', 'scala-sbt.org');
     ga('send', 'pageview');
     </script>
-    <script type="text/javascript" async>
+    <script type="text/plain" class="optanon-category-2" async>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
@eed3si9n 

Prevents GA from loading if user opts out. Adds standard legal footer, preference center and cookie listing.

If you'd like to test locally, then you need to swap out the One Trust include, template files line 19:
`<script src="https://optanon.blob.core.windows.net/consent/d759c5db-6821-46e0-a988-6bc699efb74e-test.js" type="text/javascript" charset="UTF-8"></script>`

![screenshot-localhost-8000-2018 04 30-17-45-16](https://user-images.githubusercontent.com/1418129/39457078-232e726a-4ca0-11e8-97ff-6b21017c5604.png)
![screenshot-localhost-8000-2018 04 30-17-48-23](https://user-images.githubusercontent.com/1418129/39457079-234823ea-4ca0-11e8-9826-0547132b3c79.png)
![screenshot-localhost-8000-2018 04 30-17-48-56](https://user-images.githubusercontent.com/1418129/39457080-235f8bb6-4ca0-11e8-9c6b-81281113feae.png)
