### PR TITLE
Move download links for 0.13.x to IBM Cloud in the download page

### DIFF
--- a/src/nanoc/content/download.html
+++ b/src/nanoc/content/download.html
@@ -123,23 +123,23 @@ sudo yum install sbt
 <ul>
 <li>
   sbt 0.13.17
-  (<a href="https://github.com/sbt/sbt/releases/download/v0.13.17/sbt-0.13.17.zip">.zip</a>)
-  (<a href="https://github.com/sbt/sbt/releases/download/v0.13.17/sbt-0.13.17.tgz">.tgz</a>)
-  (<a href="https://github.com/sbt/sbt/releases/download/v0.13.17/sbt-0.13.17.msi">.msi</a>)
+  (<a href="https://piccolo.link/sbt-0.13.17.zip">.zip</a>)
+  (<a href="https://piccolo.link/sbt-0.13.17.tgz">.tgz</a>)
+  (<a href="https://piccolo.link/sbt-0.13.17.msi">.msi</a>)
 </li>
 
 <li>
   sbt 0.13.16
-  (<a href="https://cocl.us/sbt-0.13.16.zip">.zip</a>)
-  (<a href="https://cocl.us/sbt-0.13.16.tgz">.tgz</a>)
-  (<a href="https://cocl.us/sbt-0.13.16.msi">.msi</a>)
+  (<a href="https://piccolo.link/sbt-0.13.16.zip">.zip</a>)
+  (<a href="https://piccolo.link/sbt-0.13.16.tgz">.tgz</a>)
+  (<a href="https://piccolo.link/sbt-0.13.16.msi">.msi</a>)
 </li>
 
 <li>
   sbt 0.13.15
-  (<a href="https://github.com/sbt/sbt/releases/download/v0.13.15/sbt-0.13.15.zip">.zip</a>)
-  (<a href="https://github.com/sbt/sbt/releases/download/v0.13.15/sbt-0.13.15.tgz">.tgz</a>)
-  (<a href="https://github.com/sbt/sbt/releases/download/v0.13.15/sbt-0.13.15.msi">.msi</a>)
+  (<a href="https://piccolo.link/sbt-0.13.15.zip">.zip</a>)
+  (<a href="https://piccolo.link/sbt-0.13.15.tgz">.tgz</a>)
+  (<a href="https://piccolo.link/sbt-0.13.15.msi">.msi</a>)
 </li>
 
 </ul>


### PR DESCRIPTION
This pull request moves only three 0.13.x download links, so we can merge it for testing.