### PR TITLE
Split 1.x release notes

### DIFF
--- a/src/reference/01-General-Info/90-Changes/46-sbt-1.1-Release-Notes.md
+++ b/src/reference/01-General-Info/90-Changes/46-sbt-1.1-Release-Notes.md
@@ -1,0 +1,340 @@
+---
+out: sbt-1.1-Release-Notes.html
+---
+
+## sbt 1.1.x releases
+
+### sbt 1.1.2
+
+#### Bug fixes
+
+- Fixes triggered execution's resource leak by caching the watch service. [#3999][3999] by [@eatkins][@eatkins]
+- Fixes classloader inheriting the dependencies of Scala compiler during `run` [zinc#505][zinc505] by [@eed3si9n][@eed3si9n]
+- Fixes forked test concurrency issue. [#4030][4030] by [@eatkins][@eatkins]
+- Fixes `new` command leaving behind target directory [#4033][4033] by [@eed3si9n][@eed3si9n]
+- Fixes handling on null Content-Type. [lm214][lm214] by [@staale][@staale]
+- Fixes null handling of `managedChecksums` in `ivySettings` file. [lm#218][lm218] by [@IanGabes][@IanGabes]
+- Adds `sbt.boot.lock` as a JVM property to opt-out of locking. [#3927][3927] by [@dwijnand][@dwijnand]
+- Provides `SBT_GLOBAL_SERVER_DIR` env var as a workaround to long socket file path on UNIX. [#3932][3932] by [@dwijnand][@dwijnand]
+- Fixes forked runs reporting noisy "Stream closed" exception. [#3970][3970] by [@retronym][@retronym]
+- Fixes test compilation not getting included in VS Code save trigger. [#4022][4022] by [@tmiyamon][@tmiyamon]
+- Fixes sbt server responding with string id when number id passed. [#4025][4025] by [@tiqwab][@tiqwab]
+- Fixes `getDecoder` in Analysis format [zinc#502][zinc502] by [@jilen][@jilen]
+- Fixes equal / hashCode inconsistencies around Array. [zinc#513][zinc513] by [@eed3si9n][@eed3si9n]
+- Whitelists `java9-rt-ext-output` in rt export process [lp#211][lp211] by [@eatkins][@eatkins]
+- Fixes JDK version detection for Java 10 friendliness. [lp#219][lp219] by [@eed3si9n][@eed3si9n] and [@2m][@2m]
+- Fixes quoting in Windows bat file. [lp#220][lp220] by [@ForNeVeR][@ForNeVeR]
+- Fixes `-error` not suppressing startup logs. [#4036][4036] by [@eed3si9n][@eed3si9n]
+
+#### Improvements
+
+- Performance optimization around logging. [util#152][util152] by [@retronym][@retronym]
+- Performance fix by caching the hashCode of `Configuration`. [lm#213][lm213] by [@retronym][@retronym]
+- Returns error code `-33000L` on sbt server when a command fails. [#3991][3991] by [@dwijnand][@dwijnand]
+- Allows wildcards in organization and artifact. [#215][lm215] by [@dhs3000][@dhs3000]
+- Updates to latest Jsch to support stronger key exchange algorithms. [lm#217][lm217] by [@ryandbair][@ryandbair]
+- Fixes preloading of compiler bridge. [lp#222][lp222] by [@analytically][@analytically]
+
+#### Internal
+
+- Updates [contribution guide][CONTRIBUTING]. [#3960][3960]/[#4019][4019] by [@eed3si9n][@eed3si9n] and [@itohiro73][@itohiro73]
+- Deletes `buildinfo.BuildInfo` from sbt main that was intended for testing. [3967][3967] by [@dwijnand][@dwijnand] and [@xuwei-k][@xuwei-k]
+- Various improvements around Zinc benchmark by [@retronym][@retronym]
+
+#### Contributors
+
+sbt 1.1.2 was brought to you by 23 contributors, according to `git shortlog -sn --no-merges v1.1.1...v1.1.2` on sbt, zinc, librarymanagement, util, io, launcher-packege, and website: Dale Wijnand, Eugene Yokota, Jason Zaugg, Kenji Yoshida (xuwei-k), Ethan Atkins, Martijn Hoekstra, Martynas Mickevičius, Dennis Hörsch, Hosam Aly, Antonio Cunei, Friedrich von Never, Hiroshi Ito, Ian Gabes, Jilen Zhang, Mathias Bogaert, Naohisa Murakami (tiqwab), Philippus Baalman, Ryan Bair, Seth Tisue, Ståle Undheim, Takuya Miyamoto (tmiyamon), Yasuhiro Tatsuno. Thank you!
+
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@dwijnand]: http://github.com/dwijnand
+  [@cunei]: https://github.com/cunei
+  [@jvican]: https://github.com/jvican
+  [@Duhemm]: https://github.com/Duhemm
+  [@xuwei-k]: https://github.com/xuwei-k
+  [@retronym]: https://github.com/retronym
+  [@eatkins]: https://github.com/eatkins
+  [@itohiro73]: https://github.com/itohiro73
+  [@tmiyamon]: https://github.com/tmiyamon
+  [@tiqwab]: https://github.com/tiqwab
+  [@staale]: https://github.com/staale
+  [@ryandbair]: https://github.com/ryandbair
+  [@dhs3000]: https://github.com/dhs3000
+  [@IanGabes]: https://github.com/IanGabes
+  [@jilen]: https://github.com/jilen
+  [@2m]: https://github.com/2m
+  [@ForNeVeR]: https://github.com/ForNeVeR
+  [@analytically]: https://github.com/analytically
+  [3927]: https://github.com/sbt/sbt/pull/3927
+  [3932]: https://github.com/sbt/sbt/pull/3932
+  [3960]: https://github.com/sbt/sbt/pull/3960
+  [3967]: https://github.com/sbt/sbt/pull/3967
+  [3970]: https://github.com/sbt/sbt/pull/3970
+  [3999]: https://github.com/sbt/sbt/pull/3999
+  [3991]: https://github.com/sbt/sbt/pull/3991
+  [4019]: https://github.com/sbt/sbt/pull/4019
+  [4022]: https://github.com/sbt/sbt/pull/4022
+  [4025]: https://github.com/sbt/sbt/pull/4025
+  [4030]: https://github.com/sbt/sbt/pull/4030
+  [4033]: https://github.com/sbt/sbt/pull/4033
+  [4036]: https://github.com/sbt/sbt/pull/4036
+  [util152]: https://github.com/sbt/util/pull/152
+  [lm213]: https://github.com/sbt/librarymanagement/pull/213
+  [lm214]: https://github.com/sbt/librarymanagement/pull/214
+  [lm215]: https://github.com/sbt/librarymanagement/pull/215
+  [lm217]: https://github.com/sbt/librarymanagement/pull/217
+  [lm218]: https://github.com/sbt/librarymanagement/pull/218
+  [zinc502]: https://github.com/sbt/zinc/pull/502
+  [zinc505]: https://github.com/sbt/zinc/pull/505
+  [zinc513]: https://github.com/sbt/zinc/pull/513
+  [lp211]: https://github.com/sbt/sbt-launcher-package/pull/211
+  [lp219]: https://github.com/sbt/sbt-launcher-package/pull/219
+  [lp220]: https://github.com/sbt/sbt-launcher-package/pull/220
+  [lp222]: https://github.com/sbt/sbt-launcher-package/pull/222
+  [CONTRIBUTING]: https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md
+
+----
+
+### sbt 1.1.1
+
+#### Bug fixes
+
+- Fixes "Modified names for (class) is empty" error. [zinc#292][zinc292] / [zinc#484][zinc484] by [@jvican][@jvican] (Scala Center)
+- Fixes tab completion in `console` while running in batch mode as `sbt console`. [#3841][3841]/[#3876][3876] by [@eed3si9n][@eed3si9n]
+- Fixes file timestamp retrieval of missing files on Windows. [#3871][3871] / [io#120][io120] by [@cunei][@cunei]
+- Aligns the errors thrown by file timestamp implementations. Fixes [#3894][3894] / [io#121][io121] by [@j-keck][@j-keck]
+- Adds file timestamps native support for FreeBSD. [#3894][3894] / [io#124][io124] by [@cunei][@cunei]
+- Fixes JDK 10 version string parsing. [sbt/sbt-launcher-package#209][launcher209] by [@2m][@2m]
+
+#### Improvements
+
+- Deprecates `Extracted#append` in favour of `appendWithSession` or `appendWithoutSession`.  [#3865][3865] by [@dwijnand][@dwijnand]
+- Adds a new global `Boolean` setting called `autoStartServer`. See below.
+- Upgrades Scala versions used for sbt cross building `^^`. [#3923][3923] by [@dwijnand][@dwijnand]
+- Many documentation maintenance changes by [@xuwei-k][@xuwei-k].
+
+#### autoStartServer setting
+
+sbt 1.1.1 adds a new global `Boolean` setting called `autoStartServer`, which is set to `true` by default.
+When set to `true`, sbt shell will automatically start sbt server. Otherwise, it will not start the server until `startSever` command is issued. This could be used to opt out of server for security reasons.
+
+[#3922][3922] by [@swaldman][@swaldman]
+
+#### Contributors
+
+sbt 1.1.1 was brought to you by 16 contributors, according to `git shortlog -sn --no-merges v1.1.0 ..v1.1.0` on sbt, zinc, librarymanagement, util, io, and website: Kenji Yoshida (xuwei-k), Eugene Yokota, Dale Wijnand, Antonio Cunei, Steve Waldman, Arnout Engelen, Deokhwan Kim, OlegYch, Robert Walker, Jorge Vicente Cantero (jvican), Claudio Bley, Eric Peters, Lena Brüder, Seiya Mizuno, Seth Tisue, j-keck. Thank you!
+
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@dwijnand]: http://github.com/dwijnand
+  [@cunei]: https://github.com/cunei
+  [@jvican]: https://github.com/jvican
+  [@Duhemm]: https://github.com/Duhemm
+  [@j-keck]: https://github.com/j-keck
+  [@swaldman]: https://github.com/swaldman
+  [@xuwei-k]: https://github.com/xuwei-k
+  [@2m]: https://github.com/2m
+  [3871]: https://github.com/sbt/sbt/issues/3871
+  [io120]: https://github.com/sbt/io/pull/120
+  [3894]: https://github.com/sbt/sbt/issues/3894
+  [io121]: https://github.com/sbt/io/pull/121
+  [io124]: https://github.com/sbt/io/pull/124
+  [zinc292]: https://github.com/sbt/zinc/issues/292
+  [zinc484]: https://github.com/sbt/zinc/pull/484
+  [3865]: https://github.com/sbt/sbt/pull/3865
+  [3841]: https://github.com/sbt/sbt/issues/3841
+  [3876]: https://github.com/sbt/sbt/pull/3876
+  [3923]: https://github.com/sbt/sbt/pull/3923
+  [3922]: https://github.com/sbt/sbt/pull/3922
+  [launcher209]: https://github.com/sbt/sbt-launcher-package/pull/209
+
+----
+
+### sbt 1.1.0
+
+This is a feature release for sbt 1.0.x series.
+
+#### Features, fixes, changes with compatibility implications
+
+- sbt server feature is reworked in sbt 1.1.0. See below.
+- Changes `version` setting default to `0.1.0-SNAPSHOT` for compatibility with Semantic Versioning. [#3577][3577] by [@laughedelic][@laughedelic]
+
+#### Features
+
+- Unifies sbt shell and build.sbt syntax. See below.
+
+#### Fixes
+
+- Fixes `ClasspathFilter` that was causing `Class.forName` to not work in `run`. [zinc#473](https://github.com/sbt/zinc/pull/473) / [#3736](https://github.com/sbt/sbt/issues/3736) / [#3733](https://github.com/sbt/sbt/issues/3733) / [#3647](https://github.com/sbt/sbt/issues/3647) / [#3608](https://github.com/sbt/sbt/issues/3608) by [@ravwojdyla][@ravwojdyla]
+- Fixes Java compilation causing `NullPointerException` by making PositionImpl thread-safe. [zinc#465](https://github.com/sbt/zinc/pull/465) by [@eed3si9n][@eed3si9n]
+- Fixes `PollingWatchService` by preventing concurrent modification of `keysWithEvents` map. [io#90](https://github.com/sbt/io/pull/90) by [@mechkg][@mechkg], which fixes `~` related issues [#3687](https://github.com/sbt/sbt/issues/3687), [#3695](https://github.com/sbt/sbt/issues/3695), and [#3775](https://github.com/sbt/sbt/issues/3775).
+- Provides workaround for `File#lastModified()` losing millisecond-precision by using native code when possible. [io#92](https://github.com/sbt/io/pull/92)/[io#106](https://github.com/sbt/io/pull/106) by [@cunei][@cunei]
+- Fixes `IO.relativize` not working with relative path. [io#108](https://github.com/sbt/io/pull/108) by [@dwijnand][@dwijnand]
+- Fixes warning message when multiple instances are detected. [#3828](https://github.com/sbt/sbt/pull/3828) by [@eed3si9n][@eed3si9n]
+- Fixes over-compilation bug with Java 9. [zinc#450][zinc450] by [@retronym][@retronym]
+- Fixes handling of deeply nested Java classes. [zinc#423][zinc423] by [@romanowski][@romanowski]
+- Fixes JavaDoc not printing all errors. [zinc#415][zinc415] by [@raboof][@raboof]
+- Preserves JAR order in `ScalaInstance.otherJars`. [zinc#411][zinc411] by [@dwijnand][@dwijnand]
+- Fixes used name when it contains NL. [zinc#449][zinc449] by [@jilen][@jilen]
+- Fixes handling of `ThisProject`. [#3609][3609] by [@dwijnand][@dwijnand]
+- Escapes imports from sbt files, so if user creates a backquoted definition then task evalution will not fail. [#3635][3635] by [@panaeon][@panaeon]
+- Removes reference to version 0.14.0 from a warning message. [#3693][3693] by [@saniyatech][@saniyatech]
+- Fixes screpl throwing "Not a valid key: console-quick". [#3762][3762] by [@xuwei-k][@xuwei-k]
+- Restores Scala 2.13.0-M1 support. #461 by [@dwijnand][@dwijnand]
+- Fixes the encoding of Unix-like file path to use `file:///`. [#3805](https://github.com/sbt/sbt/pull/3805) by [@eed3si9n][@eed3si9n]
+- Fixes Log4J2 initialization error during startup. [#3814](https://github.com/sbt/sbt/pull/3814) by [@dwijnand][@dwijnand]
+
+#### Improvements
+
+- Filters scripted tests based on optional `project/build.properties`. See below.
+- Adds `Project#withId` to change a project's id. [#3601][3601] by [@dwijnand][@dwijnand]
+- Adds `reboot dev` command, which deletes the current artifact from the boot directory. This is useful when working with development versions of sbt. [#3659][3659] by [@eed3si9n][@eed3si9n]
+- Adds a check for a change in sbt version before `reload`. [#1055][1055]/[#3673][3673] by [@RomanIakovlev][@RomanIakovlev]
+- Adds a new setting `insideCI`, which indicates that sbt is likely running in an Continuous Integration environment. [#3672][3672] by [@RomanIakovlev][@RomanIakovlev]
+- Adds `nameOption` to `Command` trait. [#3671][3671] by [@miklos-martin][@miklos-martin]
+- Adds POSIX persmission operations in IO, such as `IO.chmod(..)`. [io#76][io76] by [@eed3si9n][@eed3si9n]
+- Treat sbt 1 modules using Semantic Versioning in the eviction warning. [lm#188][lm188] by [@eed3si9n][@eed3si9n]
+- Uses kind-projector in the code. [#3650][3650] by [@dwijnand][@dwijnand]
+- Make `displayOnly` etc methods strict in `Completions`. [#3763][3763] by [@xuwei-k][@xuwei-k]
+
+#### Unified slash syntax for sbt shell and build.sbt
+
+This adds unified slash syntax for both sbt shell and the build.sbt DSL.
+Instead of the current `<project-id>/config:intask::key`, this adds
+`<project-id>/<config-ident>/intask/key` where `<config-ident>` is the Scala identifier
+notation for the configurations like `Compile` and `Test`. (The old shell syntax will continue to function)
+
+These examples work both from the shell and in build.sbt.
+
+    Global / cancelable
+    ThisBuild / scalaVersion
+    Test / test
+    root / Compile / compile / scalacOptions
+    ProjectRef(uri("file:/xxx/helloworld/"),"root")/Compile/scalacOptions
+    Zero / Zero / name
+
+The inspect command now outputs something that can be copy-pasted:
+
+    > inspect compile
+    [info] Task: sbt.inc.Analysis
+    [info] Description:
+    [info]  Compiles sources.
+    [info] Provided by:
+    [info]  ProjectRef(uri("file:/xxx/helloworld/"),"root")/Compile/compile
+    [info] Defined at:
+    [info]  (sbt.Defaults) Defaults.scala:326
+    [info] Dependencies:
+    [info]  Compile/manipulateBytecode
+    [info]  Compile/incCompileSetup
+    ....
+
+[#1812][1812]/[#3434][3434]/[#3617][3617]/[#3620][3620] by [@eed3si9n][@eed3si9n] and [@dwijnand][@dwijnand]
+
+#### sbt server
+
+sbt server feature was reworked to use Language Server Protocol 3.0 (LSP) as the wire protocol, a protocol created by Microsoft for Visual Studio Code.
+
+To discover a running server, sbt 1.1.0 creates a port file at `./project/target/active.json` relative to a build:
+
+```
+{"uri":"local:///Users/foo/.sbt/1.0/server/0845deda85cb41abcdef/sock"}
+```
+
+`local:` indicates a UNIX domain socket. Here's how we can say hello to the server using `nc`. (`^M` can be sent `Ctrl-V` then `Return`):
+
+```
+\$ nc -U /Users/foo/.sbt/1.0/server/0845deda85cb41abcdef/sock
+Content-Length: 99^M
+^M
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "initializationOptions": { } } }^M
+```
+
+sbt server adds network access to sbt's shell command so, in addition to accepting input from the terminal, server also to accepts input from the network. Here's how we can call `compile`:
+
+```
+Content-Length: 93^M
+^M
+{ "jsonrpc": "2.0", "id": 2, "method": "sbt/exec", "params": { "commandLine": "compile" } }^M
+```
+
+The running sbt session should now queue `compile`, and return back with compiler warnings and errors, if any:
+
+```
+Content-Length: 296
+Content-Type: application/vscode-jsonrpc; charset=utf-8
+
+{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:/Users/foo/work/hellotest/Hello.scala","diagnostics":[{"range":{"start":{"line":2,"character":26},"end":{"line":2,"character":27}},"severity":1,"source":"sbt","message":"object X is not a member of package foo"}]}}
+```
+
+[#3524][3524]/[#3556][3556] by [@eed3si9n][@eed3si9n]
+
+#### VS Code extension
+
+The primary use case we have in mind for the sbt server is tooling integration such as editors and IDEs. As a proof of concept, we created a Visual Studio Code extension called [Scala (sbt)][vscode-sbt-scala].
+
+Currently this extension is able to:
+
+- Run `compile` at the root project when `*.scala` files are saved. [#3524][3524] by [@eed3si9n][@eed3si9n]
+- Display compiler errors.
+- Display log messages. [#3740][3740] by [@laughedelic][@laughedelic]
+- Jump to class definitions. [#3660][3660] by [@wpopielarski][@wpopielarski]
+
+#### Filtering scripted tests using `project/build.properties`
+
+For all scripted tests in which `project/build.properties` exist, the value of the `sbt.version` property is read. If its binary version is different from `sbtBinaryVersion in pluginCrossBuild` the test will be skipped and a message indicating this will be logged.
+
+This allows you to define scripted tests that track the minimum supported sbt versions, e.g. 0.13.9 and 1.0.0-RC2. [#3564][3564]/[#3566][3566] by [@jonas][@jonas]
+
+#### Contributors
+
+sbt 1.1.0 was brought to you by 33 contributors, according to `git shortlog -sn --no-merges v1.0.4..v1.1.0` on sbt, zinc, librarymanagement, util, io, and website: Eugene Yokota, Dale Wijnand, Antonio Cunei, Kenji Yoshida (xuwei-k), Alexey Alekhin, Simon Schäfer, Jorge Vicente Cantero (jvican), Miklos Martin, Jeffrey Olchovy, Jonas Fonseca, Andrey Artemov, Arnout Engelen, Dominik Winter, Krzysztof Romanowski, Roman Iakovlev, Wiesław Popielarski, Age Mooij, Allan Timothy Leong, Ivan Poliakov, Jason Zaugg, Jilen Zhang, Long Jinwei, Martin Duhem, Michael Stringer, Michael Wizner, Nud Teeraworamongkol, OlegYch, PanAeon, Philippus Baalman, Pierre Dal-Pra, Rafal Wojdyla, Saniya Tech, Tom Walford, and many others who contributed ideas. Thank you!
+
+  [@eed3si9n]: https://github.com/eed3si9n
+  [@dwijnand]: http://github.com/dwijnand
+  [@cunei]: https://github.com/cunei
+  [@jvican]: https://github.com/jvican
+  [@Duhemm]: https://github.com/Duhemm
+  [@jonas]: https://github.com/jonas
+  [@laughedelic]: https://github.com/laughedelic
+  [@panaeon]: https://github.com/panaeon
+  [@RomanIakovlev]: https://github.com/RomanIakovlev
+  [@miklos-martin]: https://github.com/miklos-martin
+  [@saniyatech]: https://github.com/saniyatech
+  [@xuwei-k]: https://github.com/xuwei-k
+  [@wpopielarski]: https://github.com/wpopielarski
+  [@retronym]: https://github.com/retronym
+  [@romanowski]: https://github.com/romanowski
+  [@raboof]: https://github.com/raboof
+  [@jilen]: https://github.com/jilen
+  [@mechkg]: https://github.com/mechkg
+  [@ravwojdyla]: https://github.com/ravwojdyla
+  [vscode-sbt-scala]: https://marketplace.visualstudio.com/items?itemName=lightbend.vscode-sbt-scala
+  [1812]: https://github.com/sbt/sbt/issues/1812
+  [3524]: https://github.com/sbt/sbt/pull/3524
+  [3556]: https://github.com/sbt/sbt/pull/3556
+  [3564]: https://github.com/sbt/sbt/issues/3564
+  [3566]: https://github.com/sbt/sbt/pull/3566
+  [3577]: https://github.com/sbt/sbt/pull/3577
+  [3434]: https://github.com/sbt/sbt/pull/3434
+  [3601]: https://github.com/sbt/sbt/pull/3601
+  [3609]: https://github.com/sbt/sbt/pull/3609
+  [3617]: https://github.com/sbt/sbt/pull/3617
+  [3620]: https://github.com/sbt/sbt/pull/3620
+  [3464]: https://github.com/sbt/sbt/issues/3464
+  [3635]: https://github.com/sbt/sbt/pull/3635
+  [3659]: https://github.com/sbt/sbt/pull/3659
+  [3650]: https://github.com/sbt/sbt/pull/3650
+  [3673]: https://github.com/sbt/sbt/pull/3673
+  [1055]: https://github.com/sbt/sbt/issues/1055
+  [3672]: https://github.com/sbt/sbt/pull/3672
+  [3671]: https://github.com/sbt/sbt/pull/3671
+  [3693]: https://github.com/sbt/sbt/issues/3693
+  [3763]: https://github.com/sbt/sbt/pull/3763
+  [3762]: https://github.com/sbt/sbt/pull/3762
+  [3740]: https://github.com/sbt/sbt/pull/3740
+  [3660]: https://github.com/sbt/sbt/pull/3660
+  [io76]: https://github.com/sbt/io/pull/76
+  [lm188]: https://github.com/sbt/librarymanagement/pull/188
+  [zinc450]: https://github.com/sbt/zinc/pull/450
+  [zinc423]: https://github.com/sbt/zinc/pull/423
+  [zinc415]: https://github.com/sbt/zinc/issues/415
+  [zinc411]: https://github.com/sbt/zinc/pull/411
+  [zinc449]: https://github.com/sbt/zinc/pull/449

--- a/src/reference/01-General-Info/90-Changes/47-sbt-1.0-Release-Notes.md
+++ b/src/reference/01-General-Info/90-Changes/47-sbt-1.0-Release-Notes.md
@@ -2,342 +2,13 @@
 out: sbt-1.0-Release-Notes.html
 ---
 
-## sbt 1.1.2
+## sbt 1.0.x releases
 
-### Bug fixes
-
-- Fixes triggered execution's resource leak by caching the watch service. [#3999][3999] by [@eatkins][@eatkins]
-- Fixes classloader inheriting the dependencies of Scala compiler during `run` [zinc#505][zinc505] by [@eed3si9n][@eed3si9n]
-- Fixes forked test concurrency issue. [#4030][4030] by [@eatkins][@eatkins]
-- Fixes `new` command leaving behind target directory [#4033][4033] by [@eed3si9n][@eed3si9n]
-- Fixes handling on null Content-Type. [lm214][lm214] by [@staale][@staale]
-- Fixes null handling of `managedChecksums` in `ivySettings` file. [lm#218][lm218] by [@IanGabes][@IanGabes]
-- Adds `sbt.boot.lock` as a JVM property to opt-out of locking. [#3927][3927] by [@dwijnand][@dwijnand]
-- Provides `SBT_GLOBAL_SERVER_DIR` env var as a workaround to long socket file path on UNIX. [#3932][3932] by [@dwijnand][@dwijnand]
-- Fixes forked runs reporting noisy "Stream closed" exception. [#3970][3970] by [@retronym][@retronym]
-- Fixes test compilation not getting included in VS Code save trigger. [#4022][4022] by [@tmiyamon][@tmiyamon]
-- Fixes sbt server responding with string id when number id passed. [#4025][4025] by [@tiqwab][@tiqwab]
-- Fixes `getDecoder` in Analysis format [zinc#502][zinc502] by [@jilen][@jilen]
-- Fixes equal / hashCode inconsistencies around Array. [zinc#513][zinc513] by [@eed3si9n][@eed3si9n]
-- Whitelists `java9-rt-ext-output` in rt export process [lp#211][lp211] by [@eatkins][@eatkins]
-- Fixes JDK version detection for Java 10 friendliness. [lp#219][lp219] by [@eed3si9n][@eed3si9n] and [@2m][@2m]
-- Fixes quoting in Windows bat file. [lp#220][lp220] by [@ForNeVeR][@ForNeVeR]
-- Fixes `-error` not suppressing startup logs. [#4036][4036] by [@eed3si9n][@eed3si9n]
-
-### Improvements
-
-- Performance optimization around logging. [util#152][util152] by [@retronym][@retronym]
-- Performance fix by caching the hashCode of `Configuration`. [lm#213][lm213] by [@retronym][@retronym]
-- Returns error code `-33000L` on sbt server when a command fails. [#3991][3991] by [@dwijnand][@dwijnand]
-- Allows wildcards in organization and artifact. [#215][lm215] by [@dhs3000][@dhs3000]
-- Updates to latest Jsch to support stronger key exchange algorithms. [lm#217][lm217] by [@ryandbair][@ryandbair]
-- Fixes preloading of compiler bridge. [lp#222][lp222] by [@analytically][@analytically]
-
-### Internal
-
-- Updates [contribution guide][CONTRIBUTING]. [#3960][3960]/[#4019][4019] by [@eed3si9n][@eed3si9n] and [@itohiro73][@itohiro73]
-- Deletes `buildinfo.BuildInfo` from sbt main that was intended for testing. [3967][3967] by [@dwijnand][@dwijnand] and [@xuwei-k][@xuwei-k]
-- Various improvements around Zinc benchmark by [@retronym][@retronym]
-
-### Contributors
-
-sbt 1.1.2 was brought to you by 23 contributors, according to `git shortlog -sn --no-merges v1.1.1...v1.1.2` on sbt, zinc, librarymanagement, util, io, launcher-packege, and website: Dale Wijnand, Eugene Yokota, Jason Zaugg, Kenji Yoshida (xuwei-k), Ethan Atkins, Martijn Hoekstra, Martynas Mickevičius, Dennis Hörsch, Hosam Aly, Antonio Cunei, Friedrich von Never, Hiroshi Ito, Ian Gabes, Jilen Zhang, Mathias Bogaert, Naohisa Murakami (tiqwab), Philippus Baalman, Ryan Bair, Seth Tisue, Ståle Undheim, Takuya Miyamoto (tmiyamon), Yasuhiro Tatsuno. Thank you!
-
-  [@eed3si9n]: https://github.com/eed3si9n
-  [@dwijnand]: http://github.com/dwijnand
-  [@cunei]: https://github.com/cunei
-  [@jvican]: https://github.com/jvican
-  [@Duhemm]: https://github.com/Duhemm
-  [@xuwei-k]: https://github.com/xuwei-k
-  [@retronym]: https://github.com/retronym
-  [@eatkins]: https://github.com/eatkins
-  [@itohiro73]: https://github.com/itohiro73
-  [@tmiyamon]: https://github.com/tmiyamon
-  [@tiqwab]: https://github.com/tiqwab
-  [@staale]: https://github.com/staale
-  [@ryandbair]: https://github.com/ryandbair
-  [@dhs3000]: https://github.com/dhs3000
-  [@IanGabes]: https://github.com/IanGabes
-  [@jilen]: https://github.com/jilen
-  [@2m]: https://github.com/2m
-  [@ForNeVeR]: https://github.com/ForNeVeR
-  [@analytically]: https://github.com/analytically
-  [3927]: https://github.com/sbt/sbt/pull/3927
-  [3932]: https://github.com/sbt/sbt/pull/3932
-  [3960]: https://github.com/sbt/sbt/pull/3960
-  [3967]: https://github.com/sbt/sbt/pull/3967
-  [3970]: https://github.com/sbt/sbt/pull/3970
-  [3999]: https://github.com/sbt/sbt/pull/3999
-  [3991]: https://github.com/sbt/sbt/pull/3991
-  [4019]: https://github.com/sbt/sbt/pull/4019
-  [4022]: https://github.com/sbt/sbt/pull/4022
-  [4025]: https://github.com/sbt/sbt/pull/4025
-  [4030]: https://github.com/sbt/sbt/pull/4030
-  [4033]: https://github.com/sbt/sbt/pull/4033
-  [4036]: https://github.com/sbt/sbt/pull/4036
-  [util152]: https://github.com/sbt/util/pull/152
-  [lm213]: https://github.com/sbt/librarymanagement/pull/213
-  [lm214]: https://github.com/sbt/librarymanagement/pull/214
-  [lm215]: https://github.com/sbt/librarymanagement/pull/215
-  [lm217]: https://github.com/sbt/librarymanagement/pull/217
-  [lm218]: https://github.com/sbt/librarymanagement/pull/218
-  [zinc502]: https://github.com/sbt/zinc/pull/502
-  [zinc505]: https://github.com/sbt/zinc/pull/505
-  [zinc513]: https://github.com/sbt/zinc/pull/513
-  [lp211]: https://github.com/sbt/sbt-launcher-package/pull/211
-  [lp219]: https://github.com/sbt/sbt-launcher-package/pull/219
-  [lp220]: https://github.com/sbt/sbt-launcher-package/pull/220
-  [lp222]: https://github.com/sbt/sbt-launcher-package/pull/222
-  [CONTRIBUTING]: https://github.com/sbt/sbt/blob/1.x/CONTRIBUTING.md
-
-## sbt 1.1.1
-
-### Bug fixes
-
-- Fixes "Modified names for (class) is empty" error. [zinc#292][zinc292] / [zinc#484][zinc484] by [@jvican][@jvican] (Scala Center)
-- Fixes tab completion in `console` while running in batch mode as `sbt console`. [#3841][3841]/[#3876][3876] by [@eed3si9n][@eed3si9n]
-- Fixes file timestamp retrieval of missing files on Windows. [#3871][3871] / [io#120][io120] by [@cunei][@cunei]
-- Aligns the errors thrown by file timestamp implementations. Fixes [#3894][3894] / [io#121][io121] by [@j-keck][@j-keck]
-- Adds file timestamps native support for FreeBSD. [#3894][3894] / [io#124][io124] by [@cunei][@cunei]
-- Fixes JDK 10 version string parsing. [sbt/sbt-launcher-package#209][launcher209] by [@2m][@2m]
-
-### Improvements
-
-- Deprecates `Extracted#append` in favour of `appendWithSession` or `appendWithoutSession`.  [#3865][3865] by [@dwijnand][@dwijnand]
-- Adds a new global `Boolean` setting called `autoStartServer`. See below.
-- Upgrades Scala versions used for sbt cross building `^^`. [#3923][3923] by [@dwijnand][@dwijnand]
-- Many documentation maintenance changes by [@xuwei-k][@xuwei-k].
-
-### autoStartServer setting
-
-sbt 1.1.1 adds a new global `Boolean` setting called `autoStartServer`, which is set to `true` by default.
-When set to `true`, sbt shell will automatically start sbt server. Otherwise, it will not start the server until `startSever` command is issued. This could be used to opt out of server for security reasons.
-
-[#3922][3922] by [@swaldman][@swaldman]
-
-### Contributors
-
-sbt 1.1.1 was brought to you by 16 contributors, according to `git shortlog -sn --no-merges v1.1.0 ..v1.1.0` on sbt, zinc, librarymanagement, util, io, and website: Kenji Yoshida (xuwei-k), Eugene Yokota, Dale Wijnand, Antonio Cunei, Steve Waldman, Arnout Engelen, Deokhwan Kim, OlegYch, Robert Walker, Jorge Vicente Cantero (jvican), Claudio Bley, Eric Peters, Lena Brüder, Seiya Mizuno, Seth Tisue, j-keck. Thank you!
-
-  [@eed3si9n]: https://github.com/eed3si9n
-  [@dwijnand]: http://github.com/dwijnand
-  [@cunei]: https://github.com/cunei
-  [@jvican]: https://github.com/jvican
-  [@Duhemm]: https://github.com/Duhemm
-  [@j-keck]: https://github.com/j-keck
-  [@swaldman]: https://github.com/swaldman
-  [@xuwei-k]: https://github.com/xuwei-k
-  [@2m]: https://github.com/2m
-  [3871]: https://github.com/sbt/sbt/issues/3871
-  [io120]: https://github.com/sbt/io/pull/120
-  [3894]: https://github.com/sbt/sbt/issues/3894
-  [io121]: https://github.com/sbt/io/pull/121
-  [io124]: https://github.com/sbt/io/pull/124
-  [zinc292]: https://github.com/sbt/zinc/issues/292
-  [zinc484]: https://github.com/sbt/zinc/pull/484
-  [3865]: https://github.com/sbt/sbt/pull/3865
-  [3841]: https://github.com/sbt/sbt/issues/3841
-  [3876]: https://github.com/sbt/sbt/pull/3876
-  [3923]: https://github.com/sbt/sbt/pull/3923
-  [3922]: https://github.com/sbt/sbt/pull/3922
-  [launcher209]: https://github.com/sbt/sbt-launcher-package/pull/209
-
-## sbt 1.1.0
-
-This is a feature release for sbt 1.0.x series.
-
-### Features, fixes, changes with compatibility implications
-
-- sbt server feature is reworked in sbt 1.1.0. See below.
-- Changes `version` setting default to `0.1.0-SNAPSHOT` for compatibility with Semantic Versioning. [#3577][3577] by [@laughedelic][@laughedelic]
-
-### Features
-
-- Unifies sbt shell and build.sbt syntax. See below.
-
-### Fixes
-
-- Fixes `ClasspathFilter` that was causing `Class.forName` to not work in `run`. [zinc#473](https://github.com/sbt/zinc/pull/473) / [#3736](https://github.com/sbt/sbt/issues/3736) / [#3733](https://github.com/sbt/sbt/issues/3733) / [#3647](https://github.com/sbt/sbt/issues/3647) / [#3608](https://github.com/sbt/sbt/issues/3608) by [@ravwojdyla][@ravwojdyla]
-- Fixes Java compilation causing `NullPointerException` by making PositionImpl thread-safe. [zinc#465](https://github.com/sbt/zinc/pull/465) by [@eed3si9n][@eed3si9n]
-- Fixes `PollingWatchService` by preventing concurrent modification of `keysWithEvents` map. [io#90](https://github.com/sbt/io/pull/90) by [@mechkg][@mechkg], which fixes `~` related issues [#3687](https://github.com/sbt/sbt/issues/3687), [#3695](https://github.com/sbt/sbt/issues/3695), and [#3775](https://github.com/sbt/sbt/issues/3775).
-- Provides workaround for `File#lastModified()` losing millisecond-precision by using native code when possible. [io#92](https://github.com/sbt/io/pull/92)/[io#106](https://github.com/sbt/io/pull/106) by [@cunei][@cunei]
-- Fixes `IO.relativize` not working with relative path. [io#108](https://github.com/sbt/io/pull/108) by [@dwijnand][@dwijnand]
-- Fixes warning message when multiple instances are detected. [#3828](https://github.com/sbt/sbt/pull/3828) by [@eed3si9n][@eed3si9n]
-- Fixes over-compilation bug with Java 9. [zinc#450][zinc450] by [@retronym][@retronym]
-- Fixes handling of deeply nested Java classes. [zinc#423][zinc423] by [@romanowski][@romanowski]
-- Fixes JavaDoc not printing all errors. [zinc#415][zinc415] by [@raboof][@raboof]
-- Preserves JAR order in `ScalaInstance.otherJars`. [zinc#411][zinc411] by [@dwijnand][@dwijnand]
-- Fixes used name when it contains NL. [zinc#449][zinc449] by [@jilen][@jilen]
-- Fixes handling of `ThisProject`. [#3609][3609] by [@dwijnand][@dwijnand]
-- Escapes imports from sbt files, so if user creates a backquoted definition then task evalution will not fail. [#3635][3635] by [@panaeon][@panaeon]
-- Removes reference to version 0.14.0 from a warning message. [#3693][3693] by [@saniyatech][@saniyatech]
-- Fixes screpl throwing "Not a valid key: console-quick". [#3762][3762] by [@xuwei-k][@xuwei-k]
-- Restores Scala 2.13.0-M1 support. #461 by [@dwijnand][@dwijnand]
-- Fixes the encoding of Unix-like file path to use `file:///`. [#3805](https://github.com/sbt/sbt/pull/3805) by [@eed3si9n][@eed3si9n]
-- Fixes Log4J2 initialization error during startup. [#3814](https://github.com/sbt/sbt/pull/3814) by [@dwijnand][@dwijnand]
-
-### Improvements
-
-- Filters scripted tests based on optional `project/build.properties`. See below.
-- Adds `Project#withId` to change a project's id. [#3601][3601] by [@dwijnand][@dwijnand]
-- Adds `reboot dev` command, which deletes the current artifact from the boot directory. This is useful when working with development versions of sbt. [#3659][3659] by [@eed3si9n][@eed3si9n]
-- Adds a check for a change in sbt version before `reload`. [#1055][1055]/[#3673][3673] by [@RomanIakovlev][@RomanIakovlev]
-- Adds a new setting `insideCI`, which indicates that sbt is likely running in an Continuous Integration environment. [#3672][3672] by [@RomanIakovlev][@RomanIakovlev]
-- Adds `nameOption` to `Command` trait. [#3671][3671] by [@miklos-martin][@miklos-martin]
-- Adds POSIX persmission operations in IO, such as `IO.chmod(..)`. [io#76][io76] by [@eed3si9n][@eed3si9n]
-- Treat sbt 1 modules using Semantic Versioning in the eviction warning. [lm#188][lm188] by [@eed3si9n][@eed3si9n]
-- Uses kind-projector in the code. [#3650][3650] by [@dwijnand][@dwijnand]
-- Make `displayOnly` etc methods strict in `Completions`. [#3763][3763] by [@xuwei-k][@xuwei-k]
-
-### Unified slash syntax for sbt shell and build.sbt
-
-This adds unified slash syntax for both sbt shell and the build.sbt DSL.
-Instead of the current `<project-id>/config:intask::key`, this adds
-`<project-id>/<config-ident>/intask/key` where `<config-ident>` is the Scala identifier
-notation for the configurations like `Compile` and `Test`. (The old shell syntax will continue to function)
-
-These examples work both from the shell and in build.sbt.
-
-    Global / cancelable
-    ThisBuild / scalaVersion
-    Test / test
-    root / Compile / compile / scalacOptions
-    ProjectRef(uri("file:/xxx/helloworld/"),"root")/Compile/scalacOptions
-    Zero / Zero / name
-
-The inspect command now outputs something that can be copy-pasted:
-
-    > inspect compile
-    [info] Task: sbt.inc.Analysis
-    [info] Description:
-    [info]  Compiles sources.
-    [info] Provided by:
-    [info]  ProjectRef(uri("file:/xxx/helloworld/"),"root")/Compile/compile
-    [info] Defined at:
-    [info]  (sbt.Defaults) Defaults.scala:326
-    [info] Dependencies:
-    [info]  Compile/manipulateBytecode
-    [info]  Compile/incCompileSetup
-    ....
-
-[#1812][1812]/[#3434][3434]/[#3617][3617]/[#3620][3620] by [@eed3si9n][@eed3si9n] and [@dwijnand][@dwijnand]
-
-### sbt server
-
-sbt server feature was reworked to use Language Server Protocol 3.0 (LSP) as the wire protocol, a protocol created by Microsoft for Visual Studio Code.
-
-To discover a running server, sbt 1.1.0 creates a port file at `./project/target/active.json` relative to a build:
-
-```
-{"uri":"local:///Users/foo/.sbt/1.0/server/0845deda85cb41abcdef/sock"}
-```
-
-`local:` indicates a UNIX domain socket. Here's how we can say hello to the server using `nc`. (`^M` can be sent `Ctrl-V` then `Return`):
-
-```
-\$ nc -U /Users/foo/.sbt/1.0/server/0845deda85cb41abcdef/sock
-Content-Length: 99^M
-^M
-{ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "initializationOptions": { } } }^M
-```
-
-sbt server adds network access to sbt's shell command so, in addition to accepting input from the terminal, server also to accepts input from the network. Here's how we can call `compile`:
-
-```
-Content-Length: 93^M
-^M
-{ "jsonrpc": "2.0", "id": 2, "method": "sbt/exec", "params": { "commandLine": "compile" } }^M
-```
-
-The running sbt session should now queue `compile`, and return back with compiler warnings and errors, if any:
-
-```
-Content-Length: 296
-Content-Type: application/vscode-jsonrpc; charset=utf-8
-
-{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"file:/Users/foo/work/hellotest/Hello.scala","diagnostics":[{"range":{"start":{"line":2,"character":26},"end":{"line":2,"character":27}},"severity":1,"source":"sbt","message":"object X is not a member of package foo"}]}}
-```
-
-[#3524][3524]/[#3556][3556] by [@eed3si9n][@eed3si9n]
-
-### VS Code extension
-
-The primary use case we have in mind for the sbt server is tooling integration such as editors and IDEs. As a proof of concept, we created a Visual Studio Code extension called [Scala (sbt)][vscode-sbt-scala].
-
-Currently this extension is able to:
-
-- Run `compile` at the root project when `*.scala` files are saved. [#3524][3524] by [@eed3si9n][@eed3si9n]
-- Display compiler errors.
-- Display log messages. [#3740][3740] by [@laughedelic][@laughedelic]
-- Jump to class definitions. [#3660][3660] by [@wpopielarski][@wpopielarski]
-
-### Filtering scripted tests using `project/build.properties`
-
-For all scripted tests in which `project/build.properties` exist, the value of the `sbt.version` property is read. If its binary version is different from `sbtBinaryVersion in pluginCrossBuild` the test will be skipped and a message indicating this will be logged.
-
-This allows you to define scripted tests that track the minimum supported sbt versions, e.g. 0.13.9 and 1.0.0-RC2. [#3564][3564]/[#3566][3566] by [@jonas][@jonas]
-
-### Contributors
-
-sbt 1.1.0 was brought to you by 33 contributors, according to `git shortlog -sn --no-merges v1.0.4..v1.1.0` on sbt, zinc, librarymanagement, util, io, and website: Eugene Yokota, Dale Wijnand, Antonio Cunei, Kenji Yoshida (xuwei-k), Alexey Alekhin, Simon Schäfer, Jorge Vicente Cantero (jvican), Miklos Martin, Jeffrey Olchovy, Jonas Fonseca, Andrey Artemov, Arnout Engelen, Dominik Winter, Krzysztof Romanowski, Roman Iakovlev, Wiesław Popielarski, Age Mooij, Allan Timothy Leong, Ivan Poliakov, Jason Zaugg, Jilen Zhang, Long Jinwei, Martin Duhem, Michael Stringer, Michael Wizner, Nud Teeraworamongkol, OlegYch, PanAeon, Philippus Baalman, Pierre Dal-Pra, Rafal Wojdyla, Saniya Tech, Tom Walford, and many others who contributed ideas. Thank you!
-
-  [@eed3si9n]: https://github.com/eed3si9n
-  [@dwijnand]: http://github.com/dwijnand
-  [@cunei]: https://github.com/cunei
-  [@jvican]: https://github.com/jvican
-  [@Duhemm]: https://github.com/Duhemm
-  [@jonas]: https://github.com/jonas
-  [@laughedelic]: https://github.com/laughedelic
-  [@panaeon]: https://github.com/panaeon
-  [@RomanIakovlev]: https://github.com/RomanIakovlev
-  [@miklos-martin]: https://github.com/miklos-martin
-  [@saniyatech]: https://github.com/saniyatech
-  [@xuwei-k]: https://github.com/xuwei-k
-  [@wpopielarski]: https://github.com/wpopielarski
-  [@retronym]: https://github.com/retronym
-  [@romanowski]: https://github.com/romanowski
-  [@raboof]: https://github.com/raboof
-  [@jilen]: https://github.com/jilen
-  [@mechkg]: https://github.com/mechkg
-  [@ravwojdyla]: https://github.com/ravwojdyla
-  [vscode-sbt-scala]: https://marketplace.visualstudio.com/items?itemName=lightbend.vscode-sbt-scala
-  [1812]: https://github.com/sbt/sbt/issues/1812
-  [3524]: https://github.com/sbt/sbt/pull/3524
-  [3556]: https://github.com/sbt/sbt/pull/3556
-  [3564]: https://github.com/sbt/sbt/issues/3564
-  [3566]: https://github.com/sbt/sbt/pull/3566
-  [3577]: https://github.com/sbt/sbt/pull/3577
-  [3434]: https://github.com/sbt/sbt/pull/3434
-  [3601]: https://github.com/sbt/sbt/pull/3601
-  [3609]: https://github.com/sbt/sbt/pull/3609
-  [3617]: https://github.com/sbt/sbt/pull/3617
-  [3620]: https://github.com/sbt/sbt/pull/3620
-  [3464]: https://github.com/sbt/sbt/issues/3464
-  [3635]: https://github.com/sbt/sbt/pull/3635
-  [3659]: https://github.com/sbt/sbt/pull/3659
-  [3650]: https://github.com/sbt/sbt/pull/3650
-  [3673]: https://github.com/sbt/sbt/pull/3673
-  [1055]: https://github.com/sbt/sbt/issues/1055
-  [3672]: https://github.com/sbt/sbt/pull/3672
-  [3671]: https://github.com/sbt/sbt/pull/3671
-  [3693]: https://github.com/sbt/sbt/issues/3693
-  [3763]: https://github.com/sbt/sbt/pull/3763
-  [3762]: https://github.com/sbt/sbt/pull/3762
-  [3740]: https://github.com/sbt/sbt/pull/3740
-  [3660]: https://github.com/sbt/sbt/pull/3660
-  [io76]: https://github.com/sbt/io/pull/76
-  [lm188]: https://github.com/sbt/librarymanagement/pull/188
-  [zinc450]: https://github.com/sbt/zinc/pull/450
-  [zinc423]: https://github.com/sbt/zinc/pull/423
-  [zinc415]: https://github.com/sbt/zinc/issues/415
-  [zinc411]: https://github.com/sbt/zinc/pull/411
-  [zinc449]: https://github.com/sbt/zinc/pull/449
-
-## sbt 1.0.4
+### sbt 1.0.4
 
 This is a hotfix release for sbt 1.0.x series.
 
-### Bug fixes
+#### Bug fixes
 
 - Fixes undercompilation of value classes when the underlying type changes. [zinc#444][zinc444] by [@smarter][@smarter]
 - Fixes `ArrayIndexOutOfBoundsException` on Ivy when running on Java 9. [ivy#27][ivy27] by [@xuwei-k][@xuwei-k]
@@ -353,15 +24,15 @@ This is a hotfix release for sbt 1.0.x series.
 - Registers Ivy protocol only for `http:` and `https:` to be more plugin friendly. [lm183][lm183] by [@tpunder][@tpunder]
 - Fixes script issues related to `bc` by using `expr`. [launcher-package#199][sbt-launcher-package199] by [@thatfulvioguy][@thatfulvioguy]
 
-### Enhancement
+#### Enhancement
 
 - Adds Scala 2.13.0-M2 support. [zinc#453][zinc453] by [@eed3si9n][@eed3si9n] and [@jan0sch][@jan0sch]
 
-### Internal
+#### Internal
 
 - Improves Zinc scripted testing. [zinc#440][zinc440] by [@jvican][@jvican]
 
-### Contributors
+#### Contributors
 
 A huge thank you to everyone who's helped improve sbt and Zinc 1 by using them, reporting bugs, improving our documentation, porting builds, porting plugins, and submitting and reviewing pull requests.
 
@@ -400,11 +71,13 @@ This release was brought to you by 17 contributors, according to `git shortlog -
   [sbt-launcher-package197]: https://github.com/sbt/sbt-launcher-package/pull/197
   [sbt-launcher-package199]: https://github.com/sbt/sbt-launcher-package/pull/199
 
-## sbt 1.0.3
+----
+
+### sbt 1.0.3
 
 This is a hotfix release for sbt 1.0.x series.
 
-### Bug fixes
+#### Bug fixes
 
 - Fixes `~` recompiling in loop (when a source generator or sbt-buildinfo is present). [#3501][3501]/[#3634][3634] by [@dwijnand][@dwijnand]
 - Fixes undercompilation on inheritance on same source. [zinc#424][zinc424] by [@eed3si9n][@eed3si9n]
@@ -416,11 +89,11 @@ This is a hotfix release for sbt 1.0.x series.
 - Fixes "destination file exist" error message by including the file name. [lm171][lm171] by [@leonardehrenfried][@leonardehrenfried]
 - Fixes JDK 9 warning "Illegal reflective access" in library management module and Ivy. [lm173][lm173] by [@dwijnand][@dwijnand]
 
-### Improvements
+#### Improvements
 
 - Adds `sbt.watch.mode` system property to allow switching back to old polling behaviour for watch. See below for more details.
 
-### Alternative watch mode
+#### Alternative watch mode
 
 sbt 1.0.0 introduced a new mechanism for watching for source changes based on the NIO `WatchService` in Java 1.7. On
 some platforms (namely macOS) this has led to long delays before changes are picked up. An alternative `WatchService`
@@ -437,7 +110,7 @@ options.
 
 [#3597][3597] by [@stringbean][@stringbean]
 
-### Contributors
+#### Contributors
 
 A huge thank you to everyone who's helped improve sbt and Zinc 1 by using them, reporting bugs, improving our documentation, porting builds, porting plugins, and submitting and reviewing pull requests.
 
@@ -464,11 +137,13 @@ This release was brought to you by 15 contributors, according to `git shortlog -
   [zinc431]: https://github.com/sbt/zinc/pull/431
   [zinc446]: https://github.com/sbt/zinc/pull/446
 
-## sbt 1.0.2
+----
+
+### sbt 1.0.2
 
 This is a hotfix release for sbt 1.0.x series.
 
-### Bug fixes
+#### Bug fixes
 
 - Fixes terminal echo issue. [#3507][3507] by [@kczulko][@kczulko]
 - Fixes `deliver` task, and adds `makeIvyXml` as a more sensibly named task. [#3487][3487] by [@cunei][@cunei]
@@ -481,11 +156,11 @@ This is a hotfix release for sbt 1.0.x series.
 - Adds JVM flag `sbt.gigahorse` to enable/disable the internal use of Gigahorse to workaround NPE in `JavaNetAuthenticator` when used in conjunction with `repositories` override. [lm#167][lm167] by [@cunei][@cunei]
 - Adds JVM flag `sbt.server.autostart` to enable/disable the automatic starting of sbt server with the sbt shell. This also adds new `startServer` command to manually start the server. by [@eed3si9n][@eed3si9n]
 
-### Internal
+#### Internal
 
 - Fixes unused import warnings. [#3533][3533] by [@razvan-panda][@razvan-panda]
 
-### Contributors
+#### Contributors
 
 A huge thank you to everyone who's helped improve sbt and Zinc 1 by using them, reporting bugs, improving our documentation, porting plugins, and submitting and reviewing pull requests.
 
@@ -510,11 +185,13 @@ This release was brought to you by 19 contributors, according to `git shortlog -
   [zinc386]: https://github.com/sbt/zinc/pull/386
   [lm167]: https://github.com/sbt/librarymanagement/pull/167
 
-## sbt 1.0.1
+----
+
+### sbt 1.0.1
 
 This is a hotfix release for sbt 1.0.x series.
 
-### Bug fixes
+#### Bug fixes
 
 - Fixes command support for cross building `+` command. The `+` added to sbt 1.0 traveres over the subprojects, respecting `crossScalaVersions`; however, it no longer accepted commands as arguments. This brings back the support for it. [#3446][3446] by [@jroper][@jroper]
 - Fixes `addSbtPlugin` to use the correct version of sbt during cross building. [#3442][3442] by [@dwijnand][@dwijnand]
@@ -524,7 +201,7 @@ This is a hotfix release for sbt 1.0.x series.
 - Adds an attempt to workaround intermittent `NullPointerException` arround logging. [util#121][util121] by [@eed3si9n][@eed3si9n]
 - Reverts a bad forward porting. [#3481][3481] by [@eed3si9n][@eed3si9n]
 
-### WatchSource
+#### WatchSource
 
 The watch source feature went through a major change from sbt 0.13 to sbt 1.0 using NIO; however, it did not have clear migration path, so we are rectifying that in sbt 1.0.1.
 
@@ -558,9 +235,11 @@ If you have a list of files:
   [@Duhemm]: https://github.com/Duhemm
   [@jroper]: https://github.com/jroper
 
-## sbt 1.0.0
+----
 
-### Features, fixes, changes with compatibility implications
+### sbt 1.0.0
+
+#### Features, fixes, changes with compatibility implications
 
 See [Migrating from sbt 0.13.x][Migrating-from-sbt-013x] also.
 
@@ -602,12 +281,12 @@ See [Migrating from sbt 0.13.x][Migrating-from-sbt-013x] also.
 - Drops `toError(opt: Option[String]): Unit` (equivalent to `opt foreach sys.error`); if used to wrap
     `ScalaRun#run` then the replacement is `scalaRun.run(...).failed foreach (sys error _.getMessage)`
 
-### Features
+#### Features
 
 - New incremental compiler called Zinc 1. Details below.
 - The interactive shell is adds network API. Details below.
 
-### Fixes
+#### Fixes
 
 - Fixes test content log not showing up. [#3198][3198]/[util#80][util80] by [@eed3si9n][@eed3si9n]
 - Fixes confusing log about "Unable to parse". [lm#98][lm98] by [@jvican][@jvican]
@@ -617,7 +296,7 @@ See [Migrating from sbt 0.13.x][Migrating-from-sbt-013x] also.
 - Fixes task caching of `update` task. [#3233][3233] by [@eed3si9n][@eed3si9n]
 - Fixes ncurses-JLine issue by updating to JLine 2.14.4. [util#81][util81] by [@Rogach][@Rogach]
 
-### Improvements
+#### Improvements
 
 - Scala Center contributed a Java-friendly Zinc API. This was a overhaul of the Zinc internal API for a good Scala integration with other build tools. [zinc#304][zinc304] by [@jvican][@jvican]
 - Scala Center contributed a binary format for Zinc's internal storage. See below
@@ -645,15 +324,15 @@ See [Migrating from sbt 0.13.x][Migrating-from-sbt-013x] also.
 - ApiDiff feature used to debug Zinc uses Scala implementation borrowed from Dotty. [zinc#346][zinc346] by [@Krever][@Krever]
 - In Zinc internal, make ExtractAPI use perRunCaches. [zinc#347][zinc347] by [@gheine][@gheine]
 
-### Internals
+#### Internals
 
 - Adopted Scalafmt for formatting the source code using neo-scalafmt.
 - Scala Center contributed a redesign of the scripted test framework that has batch mode execution. Scripted now reuses the same sbt instance to run sbt tests, which reduces the CI build times by 50% [#3151][3151] by [@jvican][@jvican]
 - sbt 1.0.0-M6 is built using sbt 1.0.0-M5. [#3184][3184] by [@dwijnand][@dwijnand]
 
-### Details of major changes
+#### Details of major changes
 
-### Zinc 1: Class-based name hashing
+#### Zinc 1: Class-based name hashing
 
 A major improvement brought into Zinc 1.0 by Grzegorz Kossakowski (commissioned by Lightbend) is class-based name hashing, which will speed up the incremental compilation of Scala in large projects.
 
@@ -668,7 +347,7 @@ scala/scala MatchCodeGen class:         Before 48s, After 17s (2.8x)
 
 This depends on some factors such as how your classes are organized, but you can see 3x ~ 40x improvements. The reason for the speedup is because it compiles fewer source files than before by untangling the classes from source files. In the example adding a method to scala/scala's Platform class, sbt 0.13's name hashing used to compile 72 sources, but the new Zinc compiles 6 sources.
 
-#### Zinc API changes
+##### Zinc API changes
 
 - Java classes under the `xsbti.compile` package such as `IncOptions` hides the constructor. Use the factory method `xsbti.compile.Foo.of(...)`.
 - Renames `ivyScala: IvyScala` key to `scalaModuleInfo: ScalaModuleInfo`.
@@ -676,7 +355,7 @@ This depends on some factors such as how your classes are organized, but you can
 - `xsbi.Maybe`, `xsbti.F0`, and `sxbti.F1` are changed to corresponding Java 8 classes `java.util.Optional`, `java.util.Supplier` and `java.util.Function`.
 - Removes unused "resident" option. [zinc#345][zinc345] by [@lukeindykiewicz][@lukeindykiewicz]
 
-#### sbt server: JSON API for tooling integration
+##### sbt server: JSON API for tooling integration
 
 sbt 1.0 includes server feature, which allows IDEs and other tools to query the build for settings, and invoke commands via a JSON API. Similar to the way that the interactive shell in sbt 0.13 is implemented with `shell` command, "server" is also just `shell` command that listens to both human input and network input. As a user, there should be minimal impact because of the server.
 
@@ -688,7 +367,7 @@ In March 2016, we [rebooted](http://eed3si9n.com/sbt-server-reboot) the "server"
 
 Another related feature that was added is the `bgRun` task which, for example, enables a server process to be run in the background while you run tests against it.
 
-#### Static validation of build.sbt
+##### Static validation of build.sbt
 
 sbt 1.0 prohibits `.value` calls inside the bodies of if expressions and anonymous functions in a task, `@sbtUnchecked` annotation can be used to override the check.
 
@@ -696,7 +375,7 @@ The static validation also catches if you forget to call `.value` in a body of a
 
 [#3216][3216] and [#3225][3225] by [@jvican][@jvican]
 
-#### Eviction warning presentation
+##### Eviction warning presentation
 
 sbt 1.0 improves the eviction warning presetation.
 
@@ -720,7 +399,7 @@ After:
 
 [#3202][3202] by [@eed3si9n][@eed3si9n]
 
-#### sbt-cross-building
+##### sbt-cross-building
 
 [@jrudolph][@jrudolph]'s sbt-cross-building is a plugin author's plugin.
 It adds cross command `^` and sbtVersion switch command `^^`, similar to `+` and `++`,
@@ -752,7 +431,7 @@ Then, run:
 
 [#3133][3133] by [@eed3si9n][@eed3si9n] (forward ported from 0.13.16-M1)
 
-#### CopyOptions
+##### CopyOptions
 
 sbt IO 1.0 add variant of `IO.copyFile` and `IO.copyDirectory` that accept `sbt.io.CopyOptions()`.
 `CopyOptions()` is an example of pseudo case class similar to the builder pattern.
@@ -771,7 +450,7 @@ IO.copyDirectory(source, target, CopyOptions()
 
 [io#53][io53] by [@dwijnand][@dwijnand]
 
-#### Library management API and parallel artifact download
+##### Library management API and parallel artifact download
 
 sbt 1.0 adds Library management API co-authored by Eugene Yokota ([@eed3si9n][@eed3si9n]) from Lightbend and Martin Duhem ([@Duhemm][@Duhemm]) from Scala Center.
 This API aims to abstract Apache Ivy as well as alternative dependency resolution engines Ivy, cached resolution, and Coursier.
@@ -783,7 +462,7 @@ It also introduces Gigahorse OkHttp as the Network API, and it uses Square OkHtt
 [lm#90][lm90] by [@jvican][@jvican]/[@jsuereth][@jsuereth]
 and [lm#104][lm104] by [@eed3si9n][@eed3si9n].
 
-#### Binary format for Zinc's internal storage
+##### Binary format for Zinc's internal storage
 
 Jorge ([@jvican][@jvican]) from Scala Center contributed a binary format for Zinc's internal storage using Google Procol Buffer.
 The new format provides us with three main advantages:
@@ -794,7 +473,7 @@ The new format provides us with three main advantages:
 
 [zinc#351][zinc351] by [@jvican][@jvican]
 
-#### Dependency locking
+##### Dependency locking
 
 Dependency locking feature is still in progress, but Jorge ([@jvican][@jvican]) from Scala Center has added a number of related features
 that would should work together to allow dependency locking.
@@ -803,7 +482,7 @@ that would should work together to allow dependency locking.
 - Adds support to specify a resolver for dependencies. [lm#97][lm97]
 - Adds "managed checksums", which tells Ivy to skip the checksum process. [lm#111][lm111]
 
-### Contributors
+#### Contributors
 
 Too many people to thank here. See [Credits][Credits]
 


### PR DESCRIPTION
There are a few problems with the "sbt 1.0 release notes" page.  These are well-done release notes, and they should be easier for folks to peruse.

1. Page is too long, should be split up
2. There is only one reference for all these notes in the table of contents, and confusingly it's "sbt 1.1.2" the first page-level heading.
3. Further, the file name is confusingly `sbt-1.0-Release-Notes.html`
4. There are multiple top-level headings on the page (displayed as page-wide blue banners).

For now, I've split it to two pages (in order):

1. "sbt 1.1.x release.notes"
2. "sbt 1.0.x release.notes"

These release notes could probably be split-up further a second time for each release, but this is a good first step to see what the mood is here and what the consequences are.  



