### PR TITLE
copy is private now - use withRevision

### DIFF
--- a/src/reference/04-Howto/90-Examples/04-Advanced-Command-Example.md
+++ b/src/reference/04-Howto/90-Examples/04-Advanced-Command-Example.md
@@ -64,7 +64,7 @@ object Canon extends Plugin {
   // This is the fundamental transformation.
   // Here we map all declared ScalaCheck dependencies to be version 1.8
   def mapSingle(module: ModuleID): ModuleID =
-    if(module.name == "scalacheck") module.copy(revision = "1.8") 
+    if(module.name == "scalacheck") module.withRevision(revision = "1.8") 
     else module
 }
 ```


### PR DESCRIPTION
This is a simple doc fix since `ModuleID` no longer exposes the `copy` method.