### PR TITLE
Fixed doc example

### DIFF
--- a/src/reference/04-Howto/90-Examples/04-Advanced-Command-Example.md
+++ b/src/reference/04-Howto/90-Examples/04-Advanced-Command-Example.md
@@ -40,8 +40,7 @@ object Canon extends Plugin {
     val extracted = Project.extract(state)
     import extracted._
     val transformed = session.mergeSettings map ( s => f(s) )
-    val newStructure = Load.reapply(transformed, structure)
-    Project.setProject(session, newStructure, state)
+    appendWithSession(transformed, state)
   }
 
   // Transforms a Setting[_].


### PR DESCRIPTION
Fixed the doc example for an advanced sbt command. The example uses an internal function `Load`. It now uses appendWithSession instead. (https://github.com/sbt/sbt/issues/3881)