### PR TITLE
Fix Travis CI APT Sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
   apt:
     sources:
       - sourceline: 'deb https://dl.bintray.com/sbt/debian /'
-      - key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=sbt'
+        key_url: 'https://bintray.com/user/downloadSubjectPublicKey?username=sbt'
     packages:
       - sbt=1.1.6
       - pandoc


### PR DESCRIPTION
Ref https://docs.travis-ci.com/user/installing-dependencies/#Adding-APT-Packages

https://travis-ci.org/sbt/website/jobs/401594408#L408-L410
```
Adding APT Sources (BETA)
'sourceline' key missing:
\{:key_url\=\>"https://bintray.com/user/downloadSubjectPublicKey\?username\=sbt"\}
```

