### PR TITLE
Provide further options for proxy credentials

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md
@@ -87,6 +87,15 @@ with file contents
   password=admin123
 ```
 
+If the above does not work for your system, then another approach is to explicitly provide the boot credentials via:
+
+    -Dsbt.boot.credentials\$HOME/TO/.ivy2/credentials
+  
+As well as add the credentials to your build file directly:
+
+    credentials += Credentials(Path.userHome / ".ivy2" / "credentials")
+    
+
 #### Launcher Script
 
 The sbt launcher supports two configuration options that allow the usage


### PR DESCRIPTION
The provided details do not work on all systems, so add the notes from https://stackoverflow.com/questions/40224921/sbt-is-unable-to-find-credentials-when-attempting-to-download-from-an-artifactor/40411532#40411532