### PR TITLE
Tweak cached resolution example to be more concise

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/08-Cached-Resolution.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/08-Cached-Resolution.md
@@ -15,7 +15,7 @@ Cached resolution is an **experimental** feature of sbt added since 0.13.7 to ad
 To set up cached resolution include the following setting in your project's build:
 
 ```scala
-updateOptions := updateOptions.value.withCachedResolution(true)
+updateOptions ~= { _.withCachedResolution(true) }
 ```
 
 ### Dependency as a graph


### PR DESCRIPTION
Using the `~=` operator is more concise here, right?