### PR TITLE
Page “sbt new and Templates”: remove mention of template “akka/hello-akka.g8”

### DIFF
--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/06-sbt-new-and-Templates.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/06-sbt-new-and-Templates.md
@@ -46,7 +46,6 @@ The unique aspect of Giter8 is that it uses GitHub (or any other git repository)
 )
 - [akka/akka-java-seed.g8](https://github.com/akka/akka-java-seed.g8)                   (A minimal seed template for an Akka in Java
 )
-- [akka/hello-akka.g8](https://github.com/akka/hello-akka.g8)                           (Simple Akka application)
 - [playframework/play-scala-seed.g8](https://github.com/playframework/play-scala-seed.g8) (Play Scala Seed Template)
 - [playframework/play-java-seed.g8](https://github.com/playframework/play-java-seed.g8)   (Play Java Seed template)
 - [lagom/lagom-scala.g8](https://github.com/lagom/lagom-scala.g8/)                      (A [Lagom](https://www.lagomframework.com/) Scala seed template for sbt)


### PR DESCRIPTION
[`akka/hello-akka.g8`](https://github.com/akka/hello-akka.g8) is not a public project.

```
$ sbt -v new akka/hello-akka.g8
[process_args] java_version = '8'
# Executing command line:
java
-Xms1024m
-Xmx1024m
-XX:ReservedCodeCacheSize=128m
-XX:MaxMetaspaceSize=256m
-jar
/usr/share/sbt/bin/sbt-launch.jar
new
akka/hello-akka.g8
[info] Set current project to foo (in build file:foo/)
[info] Set current project to foo (in build file:foo/)
Username: 
Password: 
Username: 
Password: 
Username: 
Password: 
https://github.com/akka/hello-akka.g8.git: not authorized
```