### PR TITLE
Add sbt-source-format to community plugins

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -46,6 +46,8 @@ your plugin to the list.
   formatting using Scalafmt. <!-- 80 stars -->
 - [sbt-java-formatter](https://github.com/sbt/sbt-java-formatter):
   code formatting for Java sources. <!-- 8 stars -->
+- [sbt-source-format](https://github.com/swoval/sbt-source-format):
+  code formatting for Java and clang (c/c++/objc) sources. <!-- 1 stars -->
 
 #### Documentation plugins
 


### PR DESCRIPTION
I recently added an sbt plugin that formats both java (using the same
google library as sbt-java-formatter) as well as clang-format. The
clang-format support is useful if you have a project with jni code.