### PR TITLE
Update link to "external-maven-ivy"

### DIFF
--- a/src/reference/00-Getting-Started/08-Library-Dependencies.md
+++ b/src/reference/00-Getting-Started/08-Library-Dependencies.md
@@ -5,7 +5,7 @@ out: Library-Dependencies.html
   [Basic-Def]: Basic-Def.html
   [Scopes]: Scopes.html
   [Task-Graph]: Task-Graph.html
-  [external-maven-ivy]: ../docs/Library-Management.html#external-maven-ivy
+  [external-maven-ivy]: ../docs/Library-Management.html#External+Maven+or+Ivy
   [Cross-Build]: ../docs/Cross-Build.html
   [Resolvers]: ../docs/Resolvers.html
   [Library-Management]: ../docs/Library-Management.html


### PR DESCRIPTION
The old link was not scrolling to the relevant section