### PR TITLE
Add missing removal of `~/.ivy2/.sbt.ivy.lock`

### DIFF
--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/04-Travis-CI-with-sbt.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/04-Travis-CI-with-sbt.md
@@ -196,6 +196,7 @@ Finally, the following a few lines of cleanup script are added:
 ```yml
 before_cache:
   # Cleanup the cached directories to avoid unnecessary cache updates
+  - rm -fv \$HOME/.ivy2/.sbt.ivy.lock
   - find \$HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
   - find \$HOME/.sbt        -name "*.lock"               -print -delete
 ```
@@ -337,6 +338,7 @@ before_cache:
   # Tricks to avoid unnecessary cache updates
   - find \$HOME/.sbt -name "*.lock" | xargs rm
   - find \$HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+  - rm -f \$HOME/.ivy2/.sbt.ivy.lock
 
 # Email specific recipient all the time
 notifications:


### PR DESCRIPTION
`~/.ivy2/.sbt.ivy.lock` also leads to unnecessary cache updates.