### PR TITLE
Add a link to sbt-lit

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -307,6 +307,7 @@ your plugin to the list.
   enable partial unification support in Scala (SI-2712). <!-- 2 stars -->
 - [sbt-i18n](https://github.com/ant8e/sbt-i18n):
   transform your i18n bundles into Scala code. <!-- 1 stars -->
+- [sbt-lit](https://github.com/earldouglas/sbt-lit): build literate code with sbt.
 
 #### Static code analysis plugins
 


### PR DESCRIPTION
This could fall under either documentation plugins, since documentation and literate programming are both focused on communicating with other humans, or code generator plugins, which is the sbt mechanism used to extract code from literate files.