### PR TITLE
update sbt by example to use MetaWeather

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val root = (project in file("."))
         SiteHelpers.addMappingsToSiteDir(
           mappings in Pdf.generatePdf in Pamflet,
           siteSubdirName in Pamflet,
-        ),
+        )
       )
     else Nil,
     fileEncoding := {

--- a/src/sbt-test/ref/example-library/build.sbt
+++ b/src/sbt-test/ref/example-library/build.sbt
@@ -4,6 +4,7 @@ ThisBuild / organization := "com.example"
 lazy val hello = (project in file("."))
   .settings(
     name := "Hello",
+    libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.9",
     libraryDependencies += "com.eed3si9n" %% "gigahorse-okhttp" % "0.3.1",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   )

--- a/src/sbt-test/ref/example-weather/core/src/main/scala/example/core/Weather.scala
+++ b/src/sbt-test/ref/example-weather/core/src/main/scala/example/core/Weather.scala
@@ -1,32 +1,26 @@
 package example.core
 
 import gigahorse._, support.okhttp.Gigahorse
-import scala.concurrent._
+import scala.concurrent._, duration._
 import play.api.libs.json._
 
 object Weather {
   lazy val http = Gigahorse.http(Gigahorse.config)
+
   def weather: Future[String] = {
-    val r = Gigahorse.url("https://query.yahooapis.com/v1/public/yql").get.
-      addQueryString(
-        "q" -> """select item.condition
-                 |from weather.forecast where woeid in (select woeid from geo.places(1) where text='New York, NY')
-                 |and u='c'""".stripMargin,
-        "format" -> "json"
-      )
-
-    import ExecutionContext.Implicits._
+    val baseUrl = "https://www.metaweather.com/api/location"
+    val locUrl = baseUrl + "/search/"
+    val weatherUrl = baseUrl + "/%s/"
+    val rLoc = Gigahorse.url(locUrl).get.
+      addQueryString("query" -> "New York")
+    import ExecutionContext.Implicits.global
     for {
-      f <- http.run(r, Gigahorse.asString)
-      x <- parse(f)
-    } yield x
+      loc <- http.run(rLoc, parse)
+      woeid = (loc \ 0  \ "woeid").get
+      rWeather = Gigahorse.url(weatherUrl format woeid).get
+      weather <- http.run(rWeather, parse)
+    } yield (weather \\ "weather_state_name")(0).as[String].toLowerCase
   }
 
-  def parse(rawJson: String): Future[String] = {
-    val js = Json.parse(rawJson)
-    (js \\ "text").headOption match {
-      case Some(JsString(x)) => Future.successful(x.toLowerCase)
-      case _                 => Future.failed(sys.error(rawJson))
-    }
-  }
+  private def parse = Gigahorse.asString andThen Json.parse
 }


### PR DESCRIPTION
The section _sbt by example_ was updated to use MetaWeather API since
Yahoo API now requires credentials and this is not suitable for this
case.

The trailing comma on `build.sbt` is removed since it causes `illegal
start of simple expression` warning.

See #758 and [link](https://contributors.scala-lang.org/t/help-wanted-update-sbt-getting-started-guide-for-yahoo-changes/2840)