### PR TITLE
Add a reference to the sbt-autoplugin.g8 template

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -19,6 +19,11 @@ software into one central location.
 A side benefit to using the sbt organization for projects is that you
 can use gh-pages to host websites under the https://www.scala-sbt.org domain.
 
+The [sbt autoplugin giter8 template](https://github.com/sbt/sbt-autoplugin.g8) 
+is a good place to start. This sets up a new sbt plugin project appropriately. 
+The generated `README` will includes a summary of the steps for publishing a new 
+community plugin.
+
 ### Community Ivy Repository
 
 [Lightbend](https://www.lightbend.com) has provided a freely available


### PR DESCRIPTION
The sbt-autoplugin.g8 template is a nice template for a new sbt plugin that targets publishing to the community. I didn't see an existing reference and I think this template is worth highlighting early in the instructions.