### PR TITLE
Update Travis cache settings for 1.3.x

### DIFF
--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/04-Travis-CI-with-sbt.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/04-Travis-CI-with-sbt.md
@@ -321,8 +321,10 @@ script:
 before_cache:
   # Tricks to avoid unnecessary cache updates
   - find \$HOME/.sbt -name "*.lock" | xargs rm
-  - find \$HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
-  - rm -f \$HOME/.ivy2/.sbt.ivy.lock
+  # The below tricks are not required for sbt 1.3.x and later, since it no longer use ivy.
+  # You may comment out if using sbt 1.2.x and prior.
+  # - find \$HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
+  # - rm -f \$HOME/.ivy2/.sbt.ivy.lock
 
 # Email specific recipient all the time
 notifications:


### PR DESCRIPTION
If I understand correctly, removing `.ivy`-related files before cache is no longer required, since sbt 1.3 uses Coursier instead of Ivy.

Maybe Coursier-related files should be added ?? 🤔
I am not sure since not familiar with Coursier