### PR TITLE
Update 02-sbt-by-example.md

### DIFF
--- a/src/reference/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/00-Getting-Started/02-sbt-by-example.md
@@ -64,7 +64,7 @@ sbt:foo-build> ~compile
 
 ### Create a source file
 
-Leave the previous command running. From a different shell or in your file manager create in the project
+Leave the previous command running. From a different shell or in your file manager create in the foo-build
 directory the following nested directories: `src/main/scala/example`. Then, create `Hello.scala`
 in the `example` directory using your favorite editor as follows:
 


### PR DESCRIPTION
the src/main/scala/example should be placed in the foo-build/ directory, not in the project/ directory. Otherwise recompile on code change would not work. see https://stackoverflow.com/questions/56913316/why-does-the-sbt-compile-command-do-not-recompile-on-code-change/56913535#56913535