### PR TITLE
fix: use syntax highlighting for code snippet in Datatype

### DIFF
--- a/src/reference/90-Developers-Guide/06-Datatype/00.md
+++ b/src/reference/90-Developers-Guide/06-Datatype/00.md
@@ -358,13 +358,14 @@ will still run.
 Adding `JsonCodecPlugin` to the subproject will generate sjson-new JSON codes for
 the datatypes.
 
+```scala
 lazy val root = (project in file("."))
   .enablePlugins(DatatypePlugin, JsonCodecPlugin)
   .settings(
     scalaVersion := "2.11.8",
     libraryDependencies += "com.eed3si9n" %% "sjson-new-scalajson" % "0.4.1"
   )
-
+```
 
 `codecNamespace` can be used to specify the package name for the codecs.
 


### PR DESCRIPTION
Small fix to make the code snippet more readable.