### PR TITLE
use sbt/sbt to report issues for launcher scripts

### DIFF
--- a/src/reference/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/00-Getting-Started/01-Setup/c.md
@@ -63,7 +63,7 @@ On Fedora, `sbt 0.13.1` [available on official repos](https://fedora.pkgs.org/28
     sudo dnf --enablerepo=bintray--sbt-rpm install sbt
 
 > **Note:** Please report any issues with these to the
-> [sbt-launcher-package](https://github.com/sbt/sbt-launcher-package)
+> [sbt](https://github.com/sbt/sbt)
 > project.
 
 ### Gentoo

--- a/src/reference/es/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/es/00-Getting-Started/01-Setup/c.md
@@ -92,7 +92,7 @@ de `sbt` (p.e. `sbt 1.1.6` o superior) utilizando `bintray-sbt-rpm.repo`.
     sudo dnf --enablerepo=bintray--sbt-rpm install sbt
 
 > **Nota:** Por favor, reporta cualquier problema con estos paquetes al proyecto
-> [sbt-launcher-package](https://github.com/sbt/sbt-launcher-package)
+> [sbt](https://github.com/sbt/sbt)
 
 ### Gentoo
 

--- a/src/reference/ja/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/ja/00-Getting-Started/01-Setup/c.md
@@ -68,7 +68,7 @@ sbt のバイナリは Bintray にて公開されており、Bintray は RPM リ
 そのため、このリポジトリをパッケージ・マネージャに追加する必要がある。
 
 > **注意:** これらのパッケージに問題があれば、
-> [sbt-launcher-package](https://github.com/sbt/sbt-launcher-package)
+> [sbt](https://github.com/sbt/sbt)
 > プロジェクトに報告してほしい。
 
 ### Gentoo


### PR DESCRIPTION
The end user doesn't make the distinction of what's script vs what's the program, so it's better to get all issues in one place.