### PR TITLE
Update the scala seed template name

### DIFF
--- a/src/reference/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/00-Getting-Started/02-sbt-by-example.md
@@ -546,7 +546,7 @@ or a continuous test like `~testQuick`.
 You can use the sbt `new` command to quickly setup a simple "Hello world" build.
 
 ```
-\$ sbt new sbt/scala-seed.g8
+\$ sbt new scala/scala-seed.g8
 ....
 A minimal Scala project.
 


### PR DESCRIPTION
Ran with original template sbt/scala-seed.g8 and did not give expected output, later verified that the actual Giter8 template is scala/scala-seed.g8
Tested by running:
sbt new scala/scala-seed.g8