### PR TITLE
Add sbt-no-publish

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -129,7 +129,7 @@ your plugin to the list.
   next version bump based on patterns of your commit messase since last release. <!-- 2 stars -->
 - [sbt-gcs](https://github.com/saint1991/sbt-gcs): manage objects on Google Cloud Storage. <!-- 1 star -->
 - [sbt-sourcebundler](https://github.com/kotobotov/sbt-sourcebundler): merge all source code into one scala file. <!-- 1 star -->
-- [sbt-no-publish](https://github.com/ChristopherDavenport/sbt-no-publish): Disable Project Publishing <!-- 0 stars -->
+- [sbt-no-publish](https://github.com/ChristopherDavenport/sbt-no-publish): Disable Project Publishing. <!-- 0 stars -->
 
 #### Deployment integration plugins
 

--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -129,6 +129,7 @@ your plugin to the list.
   next version bump based on patterns of your commit messase since last release. <!-- 2 stars -->
 - [sbt-gcs](https://github.com/saint1991/sbt-gcs): manage objects on Google Cloud Storage. <!-- 1 star -->
 - [sbt-sourcebundler](https://github.com/kotobotov/sbt-sourcebundler): merge all source code into one scala file. <!-- 1 star -->
+- [sbt-no-publish](https://github.com/ChristopherDavenport/sbt-no-publish): Disable Project Publishing <!-- 0 stars -->
 
 #### Deployment integration plugins
 


### PR DESCRIPTION
Simple Plugin for disabling project publication. This keeps getting duplicated everywhere so making a plugin to turn it off made sense to me.

Just enable explicitly to turn off publishing. `.enablePlugin(NoPublishPlugin)