### PR TITLE
Fix shell code for download on linux

### DIFF
--- a/src/landing/download.md
+++ b/src/landing/download.md
@@ -41,21 +41,21 @@ Windows
 
   <div class="distro_debian">
   	<h2>Linux (deb)</h2>
-<pre>
+```
 echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
 curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
 sudo apt-get update
 sudo apt-get install sbt
-</pre>
+```
   </div>
 
   <div class="distro_redhat">
   	<h2>Linux (rpm)</h2>
-<pre>
+```
 curl https://bintray.com/sbt/rpm/rpm &gt; bintray-sbt-rpm.repo
 sudo mv bintray-sbt-rpm.repo /etc/yum.repos.d/
 sudo yum install sbt
-</pre>
+```
   </div>
 
 @@@


### PR DESCRIPTION
The code to paste into the shell on the official download page for linux has some problems (at least on my machine)

- It uses unicode quotation marks instead of regular ones
- It doesn't preserve newlines

This leads to no (or bad) results when pasting it into the shell. I think the problems are added automatically by the markdown processor.

This commit substitutes the \<pre\> tag, which was initially used to display the shell lines, to code \`\`\` delimiters, which seems to fix the issue.