### PR TITLE
Update 05-Using-Sonatype.md

### DIFF
--- a/src/reference/01-General-Info/05-Using-Sonatype.md
+++ b/src/reference/01-General-Info/05-Using-Sonatype.md
@@ -127,10 +127,10 @@ somewhere safe (*e.g. NOT in the repository*). Common convention is a
 `$global_base$/sonatype.sbt` file, with the following:
 
 ```scala
-credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
+credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials")
 ```
 
-Next create a file `~/.sbt/sonatype_credential`:
+Next create a file `~/.sbt/sonatype_credentials`:
 
 ```
 realm=Sonatype Nexus Repository Manager


### PR DESCRIPTION
Make the proposed credentials file name plural, to match the name
mentioned in the [warn]ing -below. The latter is issued by the sbt
command when that file is missing locally.

[warn] Credentials file ~/.sbt/sonatype_credentials does not exist