### PR TITLE
Missing character in spelling of Compile

### DIFF
--- a/src/reference/02-DetailTopics/02-Configuration/01-Classpaths.md
+++ b/src/reference/02-DetailTopics/02-Configuration/01-Classpaths.md
@@ -55,7 +55,7 @@ Tasks that produce managed files should be inserted as follows:
 
 ```scala
 Compile / sourceGenerators +=
-    generate( (Comile / sourceManaged).value / "some_directory")
+    generate( (Compile / sourceManaged).value / "some_directory")
 ```
 
 In this example, `generate` is some function of type `File => Seq[File]`


### PR DESCRIPTION
Compile was spelled `Comile`. Correcting spelling assuming that was the intention of the author