### PR TITLE
change JavaNet1Repository to JavaNet2Repository and use proper url

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/06-Resolvers.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/06-Resolvers.md
@@ -38,8 +38,8 @@ A few predefined repositories are available and are listed below
 -   `Resolver.mavenLocal` This is the local Maven repository.
 -   `DefaultMavenRepository` This is the main Maven repository at
     <https://repo1.maven.org/maven2/> and is included by default
--   `JavaNet1Repository` This is the Maven 1 repository at
-    <http://download.java.net/maven/1/>
+-   `JavaNet2Repository` This is the java.net Maven2 Repository at
+    <https://maven.java.net/content/repositories/public/>
 -   `Resolver.sonatypeRepo("public")` (or "snapshots", "staging", "releases") This is Sonatype OSS Maven Repository at
     <https://oss.sonatype.org/content/repositories/public>
 -   `Resolver.typesafeRepo("releases")` (or "snapshots") This is Typesafe Repository at
@@ -57,7 +57,7 @@ For example, to use the `java.net` repository, use the following setting
 in your build definition:
 
 ```scala
-resolvers += JavaNet1Repository
+resolvers += JavaNet2Repository
 ```
 
 Predefined repositories will go under Resolver going forward so they are


### PR DESCRIPTION
Current SBT docs, in [section Resolvers](https://www.scala-sbt.org/1.x/docs/Resolvers.html) mention **JavaNet1Repository** that is not available.

```text
JavaNet1Repository This is the Maven 1 repository at http://download.java.net/maven/1/
```

sbt/librarymanagement [defines](https://github.com/sbt/librarymanagement/blob/develop/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala#L105-L106)

```scala
 val JavaNet2RepositoryName = "java.net Maven2 Repository"
 val JavaNet2RepositoryRoot = javanet2RepositoryRoot(useSecureResolvers)
```

with [url](https://github.com/sbt/librarymanagement/blob/develop/core/src/main/scala/sbt/librarymanagement/ResolverExtra.scala#L122-L124)

```scala
 private[sbt] def javanet2RepositoryRoot(secure: Boolean) =
    if (secure) "https://maven.java.net/content/repositories/public/"
    else "http://download.java.net/maven/2"
```

So I used https://maven.java.net/content/repositories/public/ because other URLs in docs use a secure version (https).
