### PR TITLE
Bump Java patch version

### DIFF
--- a/src/reference/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/00-Getting-Started/01-Setup/c.md
@@ -19,7 +19,7 @@ To install both JDK and sbt, consider using [SDKMAN](https://sdkman.io/).
 
 ```
 \$ sdk list java
-\$ sdk install java 11.0.4.hs-adpt
+\$ sdk install java 11.0.6.hs-adpt
 \$ sdk install sbt
 ```
 


### PR DESCRIPTION
Changed ```11.0.4.hs-adpt``` to ```11.0.6.hs-adpt``` in install command as 11.0.4 is no longer available on SDKMAN.


Currently this will require the docs to change every time  AdoptOpenJDK retires/unlists a version.
I just used SDKMAN for the first time so i assumed the guide was up to date (silly me :D) maybe explicitly forcing the user to list and select a version explicitely could prevent this fallacy for other first timers of both ```sbt``` and ```sdk```.

For example
```
# use SDKMAN to list java versions
sdk java list
# select a AdoptOpenJDK 11 release version 11.y.z  and then install it like so
sdk install java 11.<y>.<z>.hs-adpt
```