### PR TITLE
Added Scala and SBT path fragments for Ivy repo pattern

### DIFF
--- a/src/reference/90-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
+++ b/src/reference/90-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
@@ -40,7 +40,7 @@ The default configuration file for sbt as an application looks like:
 
 [repositories]
   local
-  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
   maven-central
   sonatype-snapshots: https://oss.sonatype.org/content/repositories/snapshots
 


### PR DESCRIPTION
Needs them to talk to Ivy repos, see https://github.com/sbt/website/edit/develop/src/reference/02-DetailTopics/03-Dependency-Management/04-Proxy-Repositories.md.