### PR TITLE
Add: sbt-docusaur to 02-Community-Plugins.md

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -85,7 +85,9 @@ your plugin to the list.
 - [sbt-alldocs](https://github.com/glngn/sbt-alldocs): collect all the docs for a project and dependencies into a single folder.
 - [sbt-apidoc](https://github.com/valydia/sbt-apidoc): A port of [apidocjs](https://apidocjs.com) to sbt, to document REST Api. <!-- 1 star -->
 - [sbt-github-pages](https://github.com/Kevin-Lee/sbt-github-pages)
-  ([docs](https://kevin-lee.github.io/sbt-github-pages)): publish a website to GitHub Pages with minimum effort - works well with GitHub Actions.
+  ([docs](https://kevin-lee.github.io/sbt-github-pages)): publish a website to GitHub Pages with minimal effort - works well with GitHub Actions.
+- [sbt-docusaur](https://github.com/Kevin-Lee/sbt-docusaur)
+  ([docs](https://kevin-lee.github.io/sbt-docusaur)): build a website using Docusaurus and publish to GitHub Pages with minimal effort - works well with GitHub Actions.
   
 #### One jar plugins
 


### PR DESCRIPTION
* Add: `sbt-docusaur` to `02-Community-Plugins.md`

  * GitHub: https://github.com/Kevin-Lee/sbt-docusaur
  * Website (docs): https://kevin-lee.github.io/sbt-docusaur
    Documentation is on the website but incomplete. It has enough info to use it though. I'll keep adding more.

* A word change in the description of `sbt-github-pages`, which is also my plugin.