### PR TITLE
Fix error in set scala version step

### DIFF
--- a/src/reference/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/00-Getting-Started/02-sbt-by-example.md
@@ -132,11 +132,11 @@ Hello
 [success] Total time: 1 s, completed May 6, 2018 4:10:44 PM
 ```
 
-### Set ThisBuild / scalaVersion from sbt shell
+### Set scalaVersion from sbt shell
 
 ```
-sbt:foo-build> set ThisBuild / scalaVersion := "2.12.7"
-[info] Defining ThisBuild / scalaVersion
+sbt:foo-build> set scalaVersion := "2.12.7"
+[info] Defining *:scalaVersion
 ```
 
 Check the `scalaVersion` setting:


### PR DESCRIPTION
without this fix, there is such error:

> set ThisBuild / scalaVersion := "2.12.7"
<set>:1: error: value / is not a member of object sbt.ThisBuild
ThisBuild / scalaVersion := "2.12.7"