### PR TITLE
Tip for ReloadOnSourceChanges as a global setting.

### DIFF
--- a/src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md
+++ b/src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md
@@ -78,6 +78,8 @@ files in the `project` directory). When build source changes are detected,
 the build will be reloaded and sbt will re-enter triggered execution mode
 when the reload completes.
 
+[This snippet](https://github.com/pdalpra/jvm-based-vcsh/blob/53acef1e95c8c9ebd86cbfbf1f51efa07fd13d1e/.sbt/1.0/auto-reload.sbt) can be added as a [global setting](../api/sbt/Global-Settings.html) to `~/.sbt/1.0/config.sbt` to enable `ReloadOnSourceChanges` for all sbt 1.3+ builds without breaking earlier versions.
+
 ### Clearing the screen
 
 sbt can clear the console screen before it evaluates the task or after it

--- a/src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md
+++ b/src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md
@@ -78,7 +78,22 @@ files in the `project` directory). When build source changes are detected,
 the build will be reloaded and sbt will re-enter triggered execution mode
 when the reload completes.
 
-[This snippet](https://github.com/pdalpra/jvm-based-vcsh/blob/53acef1e95c8c9ebd86cbfbf1f51efa07fd13d1e/.sbt/1.0/auto-reload.sbt) can be added as a [global setting](../api/sbt/Global-Settings.html) to `~/.sbt/1.0/config.sbt` to enable `ReloadOnSourceChanges` for all sbt 1.3+ builds without breaking earlier versions.
+The following snippet can be added as a [global setting](../api/sbt/Global-Settings.html) to `~/.sbt/1.0/config.sbt` to enable `ReloadOnSourceChanges` for all sbt 1.3+ builds without breaking earlier versions:
+```
+Def.settings {
+  try {
+    val value = Class.forName("sbt.nio.Keys$ReloadOnSourceChanges$").getDeclaredField("MODULE$").get(null)
+    val clazz = Class.forName("sbt.nio.Keys$WatchBuildSourceOption")
+    val manifest = new scala.reflect.Manifest[AnyRef]{ def runtimeClass = clazz }
+    Seq(
+      SettingKey[AnyRef]("onChangedBuildSource")(manifest, sbt.util.NoJsonWriter()) in Global := value
+    )
+  } catch {
+    case e: Throwable =>
+      Nil
+  }
+}
+```
 
 ### Clearing the screen
 


### PR DESCRIPTION
Personally, I love `Global / onChangedBuildSource := ReloadOnSourceChanges`, but some repo owners prefer not to have this setting committed to their `build.sbt`.

Naively adding as a global setting breaks projects with older sbt builds (e.g. 1.2.8):
```
/Users/doug.roper/.sbt/1.0/config.sbt:2: error: not found: value onChangedBuildSource
  Global / onChangedBuildSource := ReloadOnSourceChanges
           ^
/Users/doug.roper/.sbt/1.0/config.sbt:2: error: not found: value ReloadOnSourceChanges
  Global / onChangedBuildSource := ReloadOnSourceChanges
                                  ^
```

The best solution I can see is non-trivial, and took several hours of my weekend to arrive at. All credit to @xuwei-k and  @pdalpra for figuring it out and sharing.