### PR TITLE
Fixing unescaped dollar signs

### DIFF
--- a/src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md
+++ b/src/reference/02-DetailTopics/01-Using-sbt/05-Triggered-Execution.md
@@ -79,11 +79,12 @@ the build will be reloaded and sbt will re-enter triggered execution mode
 when the reload completes.
 
 The following snippet can be added as a [global setting](../api/sbt/Global-Settings.html) to `~/.sbt/1.0/config.sbt` to enable `ReloadOnSourceChanges` for all sbt 1.3+ builds without breaking earlier versions:
+
 ```
 Def.settings {
   try {
-    val value = Class.forName("sbt.nio.Keys$ReloadOnSourceChanges$").getDeclaredField("MODULE$").get(null)
-    val clazz = Class.forName("sbt.nio.Keys$WatchBuildSourceOption")
+    val value = Class.forName("sbt.nio.Keys\$ReloadOnSourceChanges\$").getDeclaredField("MODULE\$").get(null)
+    val clazz = Class.forName("sbt.nio.Keys\$WatchBuildSourceOption")
     val manifest = new scala.reflect.Manifest[AnyRef]{ def runtimeClass = clazz }
     Seq(
       SettingKey[AnyRef]("onChangedBuildSource")(manifest, sbt.util.NoJsonWriter()) in Global := value


### PR DESCRIPTION
Fix for dollar signs in code snippet for ReloadOnSourceChanges that cause page rendering to stop at the end of the Build sources section