### PR TITLE
Add sbt-rewarn to the list of community plugins

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -355,6 +355,8 @@ generate dependency lockfiles and check for changes at build time.
   check that you have declared all your library dependencies correctly <!-- 12 stars -->
 - [sbt-taglist](https://github.com/johanandren/sbt-taglist): find tags within
   source files (such as TODO and FIXME). <!-- 11 stars -->
+- [sbt-rewarn](https://github.com/rtimush/sbt-rewarn): always display compilation warnings,
+  despite the incremental compilation. <!-- 11 stars -->
 - [sbt-jcheckstyle](https://github.com/xerial/sbt-jcheckstyle): Java code
   style checking using Checkstyle. <!-- 6 stars -->
 - [sbt-sonar](https://github.com/mwz/sbt-sonar): integration with


### PR DESCRIPTION
I'm not sure if it should go to the "Utility and system plugins" or to the "Static code analysis plugins" sections.