### PR TITLE
Add information how to get a Logger for running a process

### DIFF
--- a/src/reference/02-DetailTopics/02-Configuration/12-Process.md
+++ b/src/reference/02-DetailTopics/02-Configuration/12-Process.md
@@ -33,6 +33,12 @@ error. You can pass a `Logger` to the `!` method to send output to the
 "find project -name *.jar" ! log
 ```
 
+You can get a `Logger` with:
+
+```scala
+val log = streams.value.log
+```
+
 If you need to set the working directory or modify the environment, call
 `scala.sys.process.Process` explicitly, passing the command sequence
 (command and argument list) or command string first and the working


### PR DESCRIPTION
It was missing - as a long time user of SBT I first tried to do `val log = streams.value` which did not work.
Took a few Google searches to find the right one.