### PR TITLE
Correct grammar in Getting Started/Directories

### DIFF
--- a/src/reference/00-Getting-Started/03-Directories.md
+++ b/src/reference/00-Getting-Started/03-Directories.md
@@ -68,7 +68,7 @@ build.sbt
 ### Build support files
 
 In addition to `build.sbt`, `project` directory can contain `.scala` files
-that defines helper objects and one-off plugins.
+that define helper objects and one-off plugins.
 See [organizing the build][Organizing-Build] for more.
 
 ```


### PR DESCRIPTION
Use correct grammar:
`files that define helper objects and one-off plugins.`
instead of
`files that defines helper objects and one-off plugins.`