### PR TITLE
Add algolia search

### DIFF
--- a/src/landing/_template/landing.st
+++ b/src/landing/_template/landing.st
@@ -23,6 +23,8 @@
       }
     </script>
     <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) end -->
+
+    <link rel="stylesheet"href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
   </head>
   <body class="landing">
     <header>
@@ -37,6 +39,10 @@
               </div>
             </div>
             <div class="col-md-9">
+              <div class="docsearch">
+                <input type="text" id="doc-search-bar" placeholder="Search...">
+                <ul class="result-container" id="result-container" style="display: none;"></ul>
+              </div>
               <div class="nav" id="topbar">
                 <a href="learn.html">Learn</a>
                 <a href="download.html">Download</a>
@@ -194,6 +200,15 @@ You can use sbt-native-packager to build native formats like Docker, sbt-release
       ga('tsTracker.require', 'linker');
       ga('tsTracker.linker:autoLink', ['typesafe.com','playframework.com','scala-lang.org','scaladays.org','spray.io','akka.io','scala-sbt.org']);
       ga('tsTracker.send', 'pageview');
+    </script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript"> docsearch({
+      apiKey: 'fbc439670f5d4e3730cdcb715c359391',
+      indexName: 'scala-lang',
+      inputSelector: '#doc-search-bar',
+      algoliaOptions: { 'facetFilters': ["language:en"] },
+      debug: true // Set debug to true if you want to inspect the dropdown
+    });
     </script>
   </body>
 </html>

--- a/src/landing/_template/landing.st
+++ b/src/landing/_template/landing.st
@@ -203,11 +203,10 @@ You can use sbt-native-packager to build native formats like Docker, sbt-release
     </script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
     <script type="text/javascript"> docsearch({
-      apiKey: 'fbc439670f5d4e3730cdcb715c359391',
-      indexName: 'scala-lang',
+      apiKey: 'e47ee877a07ea1c48722f08430d54913',
+      indexName: 'scala-sbt',
       inputSelector: '#doc-search-bar',
-      algoliaOptions: { 'facetFilters': ["language:en"] },
-      debug: true // Set debug to true if you want to inspect the dropdown
+      debug: false // Set debug to true if you want to inspect the dropdown
     });
     </script>
   </body>

--- a/src/landing/_template/page.st
+++ b/src/landing/_template/page.st
@@ -160,11 +160,10 @@
     </script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
     <script type="text/javascript"> docsearch({
-      apiKey: 'fbc439670f5d4e3730cdcb715c359391',
-      indexName: 'scala-lang',
+      apiKey: 'e47ee877a07ea1c48722f08430d54913',
+      indexName: 'scala-sbt',
       inputSelector: '#doc-search-bar',
-      algoliaOptions: { 'facetFilters': ["language:en"] },
-      debug: true // Set debug to true if you want to inspect the dropdown
+      debug: false // Set debug to true if you want to inspect the dropdown
     });
     </script>    
   </body>

--- a/src/landing/_template/page.st
+++ b/src/landing/_template/page.st
@@ -21,6 +21,8 @@
       }
     </script>
     <!-- OneTrust Cookies Consent Notice (Production Standard, scala-sbt.org, en-GB) end -->
+
+    <link rel="stylesheet"href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
   </head>
   <body class="default">
     <header>
@@ -35,6 +37,10 @@
               </div>
             </div>
             <div class="col-md-9">
+              <div class="docsearch">
+                <input type="text" class = "ds-input" id="doc-search-bar" placeholder="Search...">
+                <ul class="result-container" id="result-container" style="display: none;"></ul>
+              </div>
               <div class="nav" id="topbar">
                 <a href="/learn.html">Learn</a>
                 <a href="/download.html">Download</a>
@@ -152,5 +158,14 @@
       ga('tsTracker.linker:autoLink', ['lightbend.com','playframework.com','scala-lang.org','scaladays.org','spray.io','akka.io','scala-sbt.org']);
       ga('tsTracker.send', 'pageview');
     </script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript"> docsearch({
+      apiKey: 'fbc439670f5d4e3730cdcb715c359391',
+      indexName: 'scala-lang',
+      inputSelector: '#doc-search-bar',
+      algoliaOptions: { 'facetFilters': ["language:en"] },
+      debug: true // Set debug to true if you want to inspect the dropdown
+    });
+    </script>    
   </body>
 </html>

--- a/src/landing/assets/stylesheet.css
+++ b/src/landing/assets/stylesheet.css
@@ -16,7 +16,7 @@ body {
   text-rendering: optimizeLegibility;
 }
 body header nav .row > div {
-  float: left;
+  /* float: left; */
 }
 body header nav .row > div:last-child {
   float: right;
@@ -465,4 +465,17 @@ body .optanon-alert-box-wrapper .optanon-alert-box-bottom-padding {
     color: white
 }
 
-/* test */
+div.docsearch {
+  height:75px;
+  display:block;
+  float: left;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+div.docsearch input.ds-input {
+  max-width:200px;
+  float:left;
+}

--- a/src/reference/_sphinx/themes/sbt/layout.html
+++ b/src/reference/_sphinx/themes/sbt/layout.html
@@ -13,6 +13,8 @@
 {% set css_files = css_files + ['_static/docs.css'] %}
 {% set css_files = css_files + ['_static/syntax.css'] %}
 {% set css_files = css_files + ['https://fonts.googleapis.com/css?family=Exo:300,400,600,700'] %}
+{% set css_files = css_files + ['https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css'] %}
+
 
 {# do not display relbars #}
 {% block relbar1 %}{% endblock %}

--- a/src/reference/custom.css
+++ b/src/reference/custom.css
@@ -10,10 +10,8 @@ div.toccolumn {
 
 div.header {
   font-size: 18px;
-  color: #ffffff;
-  background-color: #ffffff;
   height: 75px;
-  border-top: 5px solid #1a84ad; /* Lightbend azure */
+  border-top: 5px solid #1a84ad; 
   -webkit-box-shadow: 0px 4px 2px 0px rgba(0,0,0,0.3);
   -moz-box-shadow: 0px 4px 2px 0px rgba(0,0,0,0.3);
   box-shadow: 0px 4px 2px 0px rgba(0,0,0,0.3);
@@ -48,10 +46,22 @@ div.header .nav {
   border-bottom: 0px solid transparent;
 }
 
-div.header #topbar {
+div.docsearch {
+  height:75px;
+  display:block;
+  float: left;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-div.header .nav a {
+div.docsearch input.ds-input {
+  max-width:200px;
+  float:left;
+}
+
+div.header .nav>a {
   display: inline-block;
   font-weight: 400;
   font-style: normal;

--- a/src/reference/layouts/footer.md
+++ b/src/reference/layouts/footer.md
@@ -34,3 +34,12 @@
 </footer>
 <script src="/assets/versions.js"></script>
 <script src="/assets/set-versions.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+  apiKey: 'fbc439670f5d4e3730cdcb715c359391',
+  indexName: 'scala-lang',
+  inputSelector: '#doc-search-bar',
+  algoliaOptions: { 'facetFilters': ["language:en"] },
+  debug: true // Set debug to true if you want to inspect the dropdown
+});
+</script>

--- a/src/reference/layouts/footer.md
+++ b/src/reference/layouts/footer.md
@@ -36,10 +36,9 @@
 <script src="/assets/set-versions.js"></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript"> docsearch({
-  apiKey: 'fbc439670f5d4e3730cdcb715c359391',
-  indexName: 'scala-lang',
+  apiKey: 'e47ee877a07ea1c48722f08430d54913',
+  indexName: 'scala-sbt',
   inputSelector: '#doc-search-bar',
-  algoliaOptions: { 'facetFilters': ["language:en"] },
-  debug: true // Set debug to true if you want to inspect the dropdown
+  debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>

--- a/src/reference/layouts/header.md
+++ b/src/reference/layouts/header.md
@@ -1,5 +1,7 @@
 <link href="https://fonts.googleapis.com/css?family=Roboto:100normal,100italic,300normal,300italic,400normal,400italic,500normal,500italic,700normal,700italic,900normal,900italicc" rel="stylesheet" type="text/css"/>
 <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700,900,400italic,700italic" rel="stylesheet" type="text/css">
+<!-- Algolia stylesheet -->
+<link href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" rel="stylesheet" type = "text/css">
 <div class="container-fluid top nav">
   <div class="row w-100">
     <div class="col-md-4">
@@ -9,15 +11,19 @@
       </div>
     </div>
     <div class="col-md-8">
-      <div class="nav" id="topbar">
-        <a href="../../learn.html">Learn</a>
-        <a href="../../download.html">Download</a>
-        <a href="../../support.html">Support</a>
-        <a href="../../community.html">Get Involved</a>
-        <a id="source-code" href="https://github.com/sbt/sbt"><img src="files/github-logo-teal.svg" alt="Source code" class="social"></a>
-        <a id="twitter" href="https://twitter.com/scala_sbt"><img src="files/twitter-logo-teal.svg" alt="sbt on Twitter" class="social"></a>
-        <a id="edit-on-github" href="https://github.com/sbt/website/edit/develop/src/reference/$page.localPath$"><img src="files/octicon-pencil.svg" alt="Edit on GitHub"></a>
-      </div>
+        <div class="docsearch">
+          <input type="text" id="doc-search-bar" placeholder="Search...">
+          <ul class="result-container" id="result-container" style="display: none;"></ul>
+        </div>
+        <div class="nav" id="topbar">
+          <a href="../../learn.html">Learn</a>
+          <a href="../../download.html">Download</a>
+          <a href="../../support.html">Support</a>
+          <a href="../../community.html">Get Involved</a>
+          <a id="source-code" href="https://github.com/sbt/sbt"><img src="files/github-logo-teal.svg" alt="Source code" class="social"></a>
+          <a id="twitter" href="https://twitter.com/scala_sbt"><img src="files/twitter-logo-teal.svg" alt="sbt on Twitter" class="social"></a>
+          <a id="edit-on-github" href="https://github.com/sbt/website/edit/develop/src/reference/$page.localPath$"><img src="files/octicon-pencil.svg" alt="Edit on GitHub"></a>
+        </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Closes #962 

To Algolia's credit, adding this was 5 minutes of following instructions and a whole day of CSS. Mostly because `layout.html` didn't do anything for some reason, so I had to add and remove lots of custom css.

Plus there's duplication of `.st` pages. 

In the end I removed all the custom CSS and decided to make Algolia's base bootstrap theme to work properly first.

Outstanding:

- [x] @eed3si9n to apply for docsearch here: https://docsearch.algolia.com/docs/apply (sorry for picking on you Eugene, not sure what the full list of maintainers looks like :-)
       
     Given that API key is public, once there's one I'll be able to test this locally without having to merge :tada: 
- [ ] Some CSS tweaks to match the theme?
- [ ] Might be able to add language-localised to pages not in English, if it's worth it? I don't know how DocSearch's indexing works

Here's what it looks now with index pointing at scala-lang.org DocSearch

1. Reference pages 
![image](https://user-images.githubusercontent.com/1052965/100518801-c3324980-318b-11eb-8357-4269a2839508.png)
2. Langing page
![image](https://user-images.githubusercontent.com/1052965/100518824-f7a60580-318b-11eb-9f90-88e98ef90585.png)
