### PR TITLE
Fix branch syntax for sbt new

### DIFF
--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/06-sbt-new-and-Templates.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/06-sbt-new-and-Templates.md
@@ -63,7 +63,7 @@ For more, see [Giter8 templates](https://github.com/foundweekends/giter8/wiki/gi
 You can append Giter8 parameters to the end of the command, so for example to specify a particular branch you can use:
 
 ```
-\$ sbt new scala/scala-seed.g8 --branch=myBranch
+\$ sbt new scala/scala-seed.g8 --branch myBranch
 ```
 
 #### How to create a Giter8 template


### PR DESCRIPTION
It seems `--branch=<branch>` does not work but without the `=` it does.

Otherwise, you'll get this error:

```
Ignoring unrecognized parameter: branch
```