### PR TITLE
clarify what DSL stands for

### DIFF
--- a/src/reference/00-Getting-Started/05-Basic-Def.md
+++ b/src/reference/00-Getting-Started/05-Basic-Def.md
@@ -60,7 +60,7 @@ The key-value pairs are listed under the `.settings(...)` method as follows:
 ### How build.sbt defines settings
 
 `build.sbt` defines subprojects, which holds a sequence of key-value pairs
-called *setting expressions* using *build.sbt DSL*.
+called *setting expressions* using *build.sbt domain-specific language(DSL)*.
 
 ```scala
 ThisBuild / organization := "com.example"


### PR DESCRIPTION
What DSL stands for is not obvious and is only expanded much later in this Getting Started Guide. 