### PR TITLE
Added updated URL for Maven Central repo1.maven.org

### DIFF
--- a/src/reference/90-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
+++ b/src/reference/90-Developers-Guide/09-Launcher/03-Launcher-Configuration.md
@@ -111,7 +111,7 @@ repositories:
 
 -   `local` - the local Ivy repository `~/.ivy2/local`.
 -   `maven-local` - The local Maven repository `~/.m2/repository`.
--   `maven-central` - The Maven Central repository `repo.maven.org`.
+-   `maven-central` - The Maven Central repository `repo1.maven.org`.
 
 Besides built in repositories, other repositories can be configured
 using the following syntax:


### PR DESCRIPTION
Just an small updated as there is a missing `1` in the url.