### PR TITLE
fix 'verion' typo; minor updates to README; update scalafmt version

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,5 @@
+version = 2.7.5
+
 maxColumn = 100
 project.git = true
 project.excludeFilters = [ /script/, ]
@@ -10,5 +12,3 @@ docstrings = JavaDoc
 spaces.inImportCurlyBraces = true
 
 trailingCommas = preserve
-
-version = "2.0.1"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 scala-sbt.org
 =============
 
-This project is the source for scala-sbt.org. See [contributors](https://github.com/sbt/website/graphs/contributors) for the list of documentation contributors.
+This project is the source for [scala-sbt.org](https://www.scala-sbt.org). It generates the contents of the site in [sbt/sbt.github.com](@ghRepo) for delivery via GitHub Pages.
 
-scala-sbt.org is powered by:
+See [contributors](https://github.com/sbt/website/graphs/contributors) for the list of documentation contributors.
+
+[scala-sbt.org](https://www.scala-sbt.org) is powered by:
 
 * [nanoc](http://nanoc.ws/) to generate the landing pages.
 
@@ -35,13 +37,13 @@ $ gem install redcarpet
 $ gem install nokogiri
 ```
 
-If you're running ubuntu, you'll need to also install ruby-dev for the native-code in redcarpet:
+If you're running Ubuntu, you'll need to also install ruby-dev for the native-code in redcarpet:
 
 ```
 $ sudo apt-get install ruby-dev
 ```
 
-Also, if you're on ubuntu you might see an error like this:
+Also, if you're on Ubuntu you might see an error like this:
 
 ```
 zlib is missing; necessary for building libxml2
@@ -55,9 +57,10 @@ $ sudo apt-get install zlib1g-dev
 
 ### Full setup
 
-The pdf generation is optional, and requires the following additional steps.
+The PDF generation is optional, and requires the following additional steps to install 
+[TeX Live](https://www.tug.org/texlive/) and [Pandoc](https://pandoc.org/).
 
-On Ubuntu
+#### On Ubuntu
 
 ```
 $ sudo add-apt-repository ppa:texlive-backports/ppa
@@ -65,11 +68,15 @@ $ sudo apt-get update
 $ sudo apt-get install pandoc latex-cjk-all texlive-full
 ```
 
-On Mac
+#### On Mac
 
-- download and install MacTEX
-- `sudo tlmgr update --self --all`
-- follow https://oku.edu.mie-u.ac.jp/~okumura/texwiki/?TeX%20Live%2FMac#bcb0d462
+These steps are derived from Haruhiko Okumura's instructions at
+[TeX Live/Mac](https://texwiki.texjp.org/?TeX%20Live%2FMac#bcb0d462 (in Japanese).
+
+- install [MacTEX](http://www.tug.org/mactex), either via 
+  [downloaded pkg](http://www.tug.org/mactex/mactex-download.html) or 
+  [homebrew mactex formulae](https://formulae.brew.sh/cask/mactex)
+- update TeX Live package manager with `sudo tlmgr update --self --all` (this may take a while)
 - `brew install pandoc`
 
 ## Usage

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -427,9 +427,9 @@ object Docs {
   // TODO: platform independence/use symlink from Java 7
   def symlink(path: String, linkFile: File, log: Logger): Unit =
     Process("ln" :: "-s" :: path :: linkFile.getAbsolutePath :: Nil) ! log match {
-      case 0 => ()
+      case 0    => ()
       case code =>
-        println(code)
         // sys.error("Could not create symbolic link '" + linkFile.getAbsolutePath + "' with path " + path)
+        println(code)
     }
 }

--- a/project/Docs.scala
+++ b/project/Docs.scala
@@ -429,6 +429,7 @@ object Docs {
     Process("ln" :: "-s" :: path :: linkFile.getAbsolutePath :: Nil) ! log match {
       case 0 => ()
       case code =>
-        println(code) // sys.error("Could not create symbolic link '" + linkFile.getAbsolutePath + "' with path " + path)
+        println(code)
+        // sys.error("Could not create symbolic link '" + linkFile.getAbsolutePath + "' with path " + path)
     }
 }

--- a/project/Pdf.scala
+++ b/project/Pdf.scala
@@ -84,14 +84,17 @@ object Pdf {
     val origLines = IO readLines file
     getFirstTitle(IO readLines file) match {
       case (Some(title), lines) =>
-        IO.write(cleanedUp, s"""---
+        IO.write(
+          cleanedUp,
+          s"""---
   title: ${title}
   ntags: [scala, sbt]
 ---
 
 Preface
 -------
-${lines mkString "\n"}""".stripMargin)
+${lines mkString "\n"}""".stripMargin
+        )
       case _ => sys.error(s"Could not find title in document ${file}")
     }
     cleanedUp

--- a/project/SiteMap.scala
+++ b/project/SiteMap.scala
@@ -31,11 +31,10 @@ object SiteMap {
 
     def relativize(files: PathFinder): Seq[(File, String)] = files pair Path.relativeTo(repoBase)
     def entries(files: PathFinder) =
-      relativize(files) flatMap {
-        case (f, path) =>
-          entry(f, path).toList map { e =>
-            entryXML(e, f, path)
-          }
+      relativize(files) flatMap { case (f, path) =>
+        entry(f, path).toList map { e =>
+          entryXML(e, f, path)
+        }
       }
     def entriesXML(entries: Seq[xml.Node]): xml.Elem = {
       assert(entries.size <= 50000, "A site map cannot contain more than 50,000 entries.")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 libraryDependencies += "org.foundweekends" %% "pamflet-library" % "0.8.2"
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.6.6")

--- a/src/reference/00-Getting-Started/05B-Multi-Project.md
+++ b/src/reference/00-Getting-Started/05B-Multi-Project.md
@@ -54,7 +54,7 @@ define the settings scoped to `ThisBuild`.
 `ThisBuild` acts as a special subproject name that you can use to define default
 value for the build.
 When you define one or more subprojects, and when the subproject does not define
-`scalaVersion` key, it will look for `ThisBuild / scalaVerion`.
+`scalaVersion` key, it will look for `ThisBuild / scalaVersion`.
 
 The limitation is that the right-hand side needs to be a pure value
 or settings scoped to `Global` or `ThisBuild`,

--- a/src/reference/01-Faq/00.md
+++ b/src/reference/01-Faq/00.md
@@ -124,7 +124,7 @@ dependencies. Read the Getting Started Guide about
 `ThisBuild` acts as a special subproject name that you can use to define default
 value for the build.
 When you define one or more subprojects, and when the subproject does not define
-`scalaVersion` key, it will look for `ThisBuild / scalaVerion`.
+`scalaVersion` key, it will look for `ThisBuild / scalaVersion`.
 
 See [build-wide settings][ThisBuild].
 


### PR DESCRIPTION
1. fix 'verion' ==> 'version' typo
2. minor updates to README to add links and clarify Mac install isntructions
3. update sbt-scalafmt and scalafmt versions (no resulting code changes required)