### PR TITLE
Scalatest version increased

### DIFF
--- a/src/sbt-test/ref/example-scalatest/build.sbt
+++ b/src/sbt-test/ref/example-scalatest/build.sbt
@@ -4,5 +4,5 @@ ThisBuild / organization := "com.example"
 lazy val hello = (project in file("."))
   .settings(
     name := "Hello",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.7" % Test,
   )

--- a/src/sbt-test/ref/example-scalatest/changes/HelloSpec.scala
+++ b/src/sbt-test/ref/example-scalatest/changes/HelloSpec.scala
@@ -1,6 +1,6 @@
-import org.scalatest._
+import org.scalatest.funsuite._
 
-class HelloSpec extends FunSuite with DiagrammedAssertions {
+class HelloSpec extends AnyFunSuite {
   test("Hello should start with H") {
     // Hello, as opposed to hello
     assert("Hello".startsWith("H"))

--- a/src/sbt-test/ref/example-scalatest/src/test/scala/HelloSpec.scala
+++ b/src/sbt-test/ref/example-scalatest/src/test/scala/HelloSpec.scala
@@ -1,6 +1,6 @@
-import org.scalatest._
+import org.scalatest.funsuite._
 
-class HelloSpec extends FunSuite with DiagrammedAssertions {
+class HelloSpec extends AnyFunSuite {
   test("Hello should start with H") {
     assert("hello".startsWith("H"))
   }

--- a/src/sbt-test/ref/example-sub1/build.sbt
+++ b/src/sbt-test/ref/example-sub1/build.sbt
@@ -5,7 +5,7 @@ lazy val hello = (project in file("."))
   .settings(
     name := "Hello",
     libraryDependencies += "com.eed3si9n" %% "gigahorse-okhttp" % "0.3.1",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.7" % Test,
   )
 
 lazy val helloCore = (project in file("core"))

--- a/src/sbt-test/ref/example-sub2/build.sbt
+++ b/src/sbt-test/ref/example-sub2/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "2.12.7"
 ThisBuild / organization := "com.example"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.7"
 
 lazy val hello = (project in file("."))
   .settings(

--- a/src/sbt-test/ref/example-sub3/build.sbt
+++ b/src/sbt-test/ref/example-sub3/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "2.12.7"
 ThisBuild / organization := "com.example"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.7"
 
 lazy val hello = (project in file("."))
   .aggregate(helloCore)

--- a/src/sbt-test/ref/example-sub4/build.sbt
+++ b/src/sbt-test/ref/example-sub4/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "2.12.7"
 ThisBuild / organization := "com.example"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.7"
 
 lazy val hello = (project in file("."))
   .aggregate(helloCore)

--- a/src/sbt-test/ref/example-weather/build.sbt
+++ b/src/sbt-test/ref/example-weather/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "2.12.7"
 ThisBuild / organization := "com.example"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.7"
 val gigahorse = "com.eed3si9n" %% "gigahorse-okhttp" % "0.3.1"
 val playJson  = "com.typesafe.play" %% "play-json" % "2.6.9"
 

--- a/src/sbt-test/ref/example-weather/changes/build.sbt
+++ b/src/sbt-test/ref/example-weather/changes/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion := "2.12.7"
 ThisBuild / organization := "com.example"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.7"
 val gigahorse = "com.eed3si9n" %% "gigahorse-okhttp" % "0.3.1"
 val playJson  = "com.typesafe.play" %% "play-json" % "2.6.9"
 

--- a/src/sbt-test/ref/example-weather/changes/build3.sbt
+++ b/src/sbt-test/ref/example-weather/changes/build3.sbt
@@ -2,7 +2,7 @@ ThisBuild / version      := "0.1.0"
 ThisBuild / scalaVersion := "2.12.7"
 ThisBuild / organization := "com.example"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+val scalaTest = "org.scalatest" %% "scalatest" % "3.2.7"
 val gigahorse = "com.eed3si9n" %% "gigahorse-okhttp" % "0.3.1"
 val playJson  = "com.typesafe.play" %% "play-json" % "2.6.9"
 


### PR DESCRIPTION
some example couldn't be compiled - I fixed it. Then I have realized that it was because I used a newer Scalatest version.  With the original Scalatest version - all is working. However, in the meantime I increased Scalatest version. 
I'm not sure whether this is useful. Feel free to cancel 