### PR TITLE
Fix the nav bar on documentation

### DIFF
--- a/src/reference/custom.css
+++ b/src/reference/custom.css
@@ -11,7 +11,7 @@ div.toccolumn {
 div.header {
   font-size: 18px;
   height: 75px;
-  border-top: 5px solid #1a84ad; 
+  border-top: 5px solid #1a84ad;
   -webkit-box-shadow: 0px 4px 2px 0px rgba(0,0,0,0.3);
   -moz-box-shadow: 0px 4px 2px 0px rgba(0,0,0,0.3);
   box-shadow: 0px 4px 2px 0px rgba(0,0,0,0.3);
@@ -20,6 +20,7 @@ div.header {
 
 div.logo {
   display: inline-block;
+  margin-left: 2em;
 }
 
 div.logo img {
@@ -35,11 +36,11 @@ div.logo img {
 }
 
 div.header div.row {
-  padding-left: 5em;
-  padding-right: 5em;
 }
 
 div.header .nav {
+  height: 75px;
+  overflow-x: hidden;
   position: relative;
   float: right;
   border-right: 1px solid #ebebeb;


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/6579

Problem
-------
The nav bar has gotten bigger over time, and on any device with lower
resolution than 1295px, it folds into the body of the text.

Solution
--------
Hardcode the height of the navbar, and hide anything that overflows.
This would gracefully scale to all screen sizes.

Before
-------

<img width="960" alt="bad" src="https://user-images.githubusercontent.com/57685970/124353502-95285280-dc0f-11eb-90a5-6be0dee76601.png">

After
-----
### Wider screen
<img width="1274" alt="1300" src="https://user-images.githubusercontent.com/184683/124361895-b123f800-dbff-11eb-871c-8f7632cbc3dc.png">

### 1116px
<img width="1204" alt="1116" src="https://user-images.githubusercontent.com/184683/124361933-f6e0c080-dbff-11eb-94af-d07d47ecd2ee.png">

### In-between 800px and 1116px
<img width="1146" alt="1000b" src="https://user-images.githubusercontent.com/184683/124361978-432c0080-dc00-11eb-9872-fd47aa359a7b.png">

### Below 800px
<img width="1081" alt="700" src="https://user-images.githubusercontent.com/184683/124361765-c2b8d000-dbfe-11eb-9598-298c423f1d2a.png">




