### PR TITLE
Using Sonatype: Replace deprecated sks-keyserver example with other keyserver

### DIFF
--- a/src/reference/01-General-Info/05-Using-Sonatype.md
+++ b/src/reference/01-General-Info/05-Using-Sonatype.md
@@ -98,7 +98,7 @@ sub   rsa4096 2018-08-22 [E]
 Distribute the key:
 
 ```
-\$ gpg --keyserver hkp://pool.sks-keyservers.net --send-keys 1234517530FB96F147C6A146A326F592D39AAAAA
+\$ gpg --keyserver keyserver.ubuntu.com --send-keys 1234517530FB96F147C6A146A326F592D39AAAAA
 ```
 
 #### step 2: sbt-pgp


### PR DESCRIPTION
[sks-keyserver](https://sks-keyservers.net/) is deprecated and no longer maintained.  

As an alternative, how about replacing the sks one with `keyserver.ubuntu.com` which is mentioned in [The Central Repository doc](https://central.sonatype.org/publish/requirements/gpg/#distributing-your-public-key)?
