### PR TITLE
Remove the x-overflow: hidden to get the search box overflow working …

### DIFF
--- a/src/reference/custom-202107.css
+++ b/src/reference/custom-202107.css
@@ -40,7 +40,6 @@ div.header div.row {
 
 div.header .nav {
   height: 75px;
-  overflow-x: hidden;
   position: relative;
   float: right;
   border-right: 1px solid #ebebeb;


### PR DESCRIPTION
…again

The search box still shows up if you make the page narrow, but I think that's ok