### PR TITLE
Add allowMachinePath description

### DIFF
--- a/src/reference/02-DetailTopics/02-Configuration/17-Remote-Caching.md
+++ b/src/reference/02-DetailTopics/02-Configuration/17-Remote-Caching.md
@@ -28,6 +28,9 @@ In the future, we might consider simpler cache server like plain HTTP server tha
 
 To abstract machine-specific paths such as your working directory and Coursier cache directory, sbt keeps a map of root paths in `ThisBuild / rootPaths`. If your build adds special paths for your source or output directory, add them to `ThisBuild / rootPaths`.
 
+If you need to guarantee that `ThisBuild / rootPaths` contains all necessary paths you can set  `ThisBuild / allowMachinePath` to `false`.
+
+
 #### remoteCacheId
 
 As of sbt 1.4.2, `remoteCacheId` uses hash of content hashes for input sources.


### PR DESCRIPTION
It is not obvious what paths should be added to ThisBuild / rootPaths in a large build . So it is very useful to know how to validate such build. 