### PR TITLE
Update use of deprecated apt-key

### DIFF
--- a/src/reference/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/00-Getting-Started/01-Setup/c.md
@@ -46,7 +46,7 @@ Run the following from the terminal to install `sbt` (You'll need superuser priv
 
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo -H gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
     sudo chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
     sudo apt-get update
     sudo apt-get install sbt

--- a/src/reference/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/00-Getting-Started/01-Setup/c.md
@@ -44,6 +44,8 @@ Download [ZIP][ZIP] or [TGZ][TGZ] package and expand it.
 Ubuntu and other Debian-based distributions use the DEB format, but usually you don't install your software from a local DEB file. Instead they come with package managers both for the command line (e.g. `apt-get`, `aptitude`) or with a graphical user interface (e.g. Synaptic).
 Run the following from the terminal to install `sbt` (You'll need superuser privileges to do so, hence the `sudo`).
 
+    sudo apt-get update
+    sudo apt-get install apt-transport-https curl gnupg -yqq
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
     curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo -H gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import

--- a/src/reference/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/00-Getting-Started/01-Setup/c.md
@@ -46,7 +46,8 @@ Run the following from the terminal to install `sbt` (You'll need superuser priv
 
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
+    sudo chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
     sudo apt-get update
     sudo apt-get install sbt
 


### PR DESCRIPTION
Before:
```shell
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
```
After:
```shell
gpg: keyring '/etc/apt/trusted.gpg.d/scalasbt-release.gpg' created
gpg: key 99E82A75642AC823: public key "sbt build tool <scalasbt@gmail.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```