### PR TITLE
add explicit `main` instead of deprecated `scala.App`

### DIFF
--- a/src/reference/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/00-Getting-Started/02-sbt-by-example.md
@@ -71,8 +71,10 @@ in the `example` directory using your favorite editor as follows:
 ```scala
 package example
 
-object Hello extends App {
-  println("Hello")
+object Hello {
+  def main(args: Array[String]): Unit = {
+    println("Hello")
+  }
 }
 ```
 
@@ -410,10 +412,12 @@ package example
 import scala.concurrent._, duration._
 import core.Weather
 
-object Hello extends App {
-  val w = Await.result(Weather.weather, 10.seconds)
-  println(s"Hello! The weather in New York is \$w.")
-  Weather.http.close()
+object Hello {
+  def main(args: Array[String]): Unit = {
+    val w = Await.result(Weather.weather, 10.seconds)
+    println(s"Hello! The weather in New York is \$w.")
+    Weather.http.close()
+  }
 }
 ```
 

--- a/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
+++ b/src/reference/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
@@ -85,8 +85,10 @@ This a trick I picked up from [earldouglas/xsbt-web-plugin@feabb2][feabb2], whic
 I also have `src/main/scala/hello.scala`:
 
 ```scala
-object Main extends App {
-  println("hello")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
 }
 ```
 

--- a/src/reference/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
+++ b/src/reference/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
@@ -14,8 +14,10 @@ Now suppose we want to call `Compile / run` task and then open the browser for t
 #### src/main/scala/Greeting.scala
 
 ```scala
-object Greeting extends App {
-  println("hello " + args.toList)
+object Greeting {
+  def main(args: Array[String]): Unit = {
+    println("hello " + args.toList)
+  }
 }
 ```
 

--- a/src/reference/es/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/es/00-Getting-Started/02-sbt-by-example.md
@@ -77,8 +77,10 @@ utilizando tu editor de texto favorito con este contenido:
 ```scala
 package example
 
-object Hello extends App {
-  println("Hello")
+object Hello {
+  def main(args: Array[String]): Unit = {
+    println("Hello")
+  }
 }
 ```
 
@@ -417,10 +419,12 @@ package example
 import scala.concurrent._, duration._
 import core.Weather
 
-object Hello extends App {
-  val w = Await.result(Weather.weather, 10.seconds)
-  println(s"Hello! The weather in New York is \$w.")
-  Weather.http.close()
+object Hello {
+  def main(args: Array[String]): Unit = {
+    val w = Await.result(Weather.weather, 10.seconds)
+    println(s"Hello! The weather in New York is \$w.")
+    Weather.http.close()
+  }
 }
 ```
 

--- a/src/reference/ja/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/ja/00-Getting-Started/02-sbt-by-example.md
@@ -69,8 +69,10 @@ sbt:foo-build> ~compile
 ```scala
 package example
 
-object Hello extends App {
-  println("Hello")
+object Hello {
+  def main(args: Array[String]): Unit = {
+    println("Hello")
+  }
 }
 ```
 
@@ -403,10 +405,12 @@ package example
 import scala.concurrent._, duration._
 import core.Weather
 
-object Hello extends App {
-  val w = Await.result(Weather.weather, 10.seconds)
-  println(s"Hello! The weather in New York is \$w.")
-  Weather.http.close()
+object Hello {
+  def main(args: Array[String]): Unit = {
+    val w = Await.result(Weather.weather, 10.seconds)
+    println(s"Hello! The weather in New York is \$w.")
+    Weather.http.close()
+  }
 }
 ```
 

--- a/src/reference/ja/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
+++ b/src/reference/ja/02-DetailTopics/05-Plugins-and-Best-Practices/05-Testing-sbt-plugins.md
@@ -86,8 +86,10 @@ sys.props.get("plugin.version") match {
 他に、`src/main/scala/hello.scala` も用意した:
 
 ```scala
-object Main extends App {
-  println("hello")
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
 }
 ```
 

--- a/src/reference/ja/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
+++ b/src/reference/ja/04-Howto/20-Howto-Sequencing/03-Howto-After-Input-Task.md
@@ -14,8 +14,10 @@ out: Howto-After-Input-Task.html
 #### src/main/scala/Greeting.scala
 
 ```scala
-object Greeting extends App {
-  println("hello " + args.toList)
+object Greeting {
+  def main(args: Array[String]): Unit = {
+    println("hello " + args.toList)
+  }
 }
 ```
 

--- a/src/sbt-test/ref/example-weather/src/main/scala/example/Hello.scala
+++ b/src/sbt-test/ref/example-weather/src/main/scala/example/Hello.scala
@@ -3,8 +3,10 @@ package example
 import scala.concurrent._, duration._
 import core.Weather
 
-object Hello extends App {
-  val w = Await.result(Weather.weather, 10.seconds)
-  println(s"Hello! The weather in New York is $w.")
-  Weather.http.close()
+object Hello {
+  def main(args: Array[String]): Unit = {
+    val w = Await.result(Weather.weather, 10.seconds)
+    println(s"Hello! The weather in New York is $w.")
+    Weather.http.close()
+  }
 }


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/book/methods-main-methods.html

> The previous functionality of App, which relied on the “magic” DelayedInit trait, is no longer available. App still exists in limited form for now, but it doesn’t support command line arguments and will be deprecated in the future.

