### PR TITLE
Update 03-Library-Management.md

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/03-Library-Management.md
@@ -182,7 +182,7 @@ resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repos
 To use the local repository, but not the Maven Central repository:
 
 ```scala
-externalResolvers := Resolver.combineDefaultResolvers(resolvers.value, mavenCentral = false)
+externalResolvers := Resolver.combineDefaultResolvers(resolvers.value.toVector, mavenCentral = false)
 ```
 
 ##### Override all resolvers for all builds


### PR DESCRIPTION
Resolver.combineDefaultResolvers's first argument is Vector[Resolver] with sbt 1.6.2. So update the 03-Library-Management.md.