### PR TITLE
Adds link to Inspecting-Settings

### DIFF
--- a/src/reference/02-DetailTopics/01-Using-sbt/01-Command-Line-Reference.md
+++ b/src/reference/02-DetailTopics/01-Using-sbt/01-Command-Line-Reference.md
@@ -174,10 +174,10 @@ configuration that can be run using a `Test/` prefix.
     reloaded, or the setting is overridden by another set command or
     removed by the session command. See
     [.sbt build definition][Basic-Def] and
-    [inspecting settings][Inspecting-Settings] for details.
+    [Inspecting Settings][Inspecting-Settings] for details.
 -   `session <command>` Manages session settings defined by the `set`
     command. It can persist settings configured at the prompt. See
-    Inspecting-Settings for details.
+    [Inspecting Settings][Inspecting-Settings] for details.
 -   `inspect <setting-key>` Displays information about settings, such as
     the value, description, defining scope, dependencies, delegation
     chain, and related settings. See


### PR DESCRIPTION
There's a "see Inspecting-Settings" in plain text in the sentence, whereas I'm assuming the intent is to have a link (as in the next sentence).

Also, for some reason the `[.sbt build definition][Basic-Def]` does not seem to be rendered properly in [the online doc](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html) just one line above, although I can't figure out why :thinking: 