### PR TITLE
Configure sbt without editing its launch script

### DIFF
--- a/src/reference/01-General-Info/05-Setup-Notes.md
+++ b/src/reference/01-General-Info/05-Setup-Notes.md
@@ -23,7 +23,7 @@ The default value of `JAVA_OPTS` is `-Dfile.encoding=UTF8`.
 
 You can also specify JVM system properties and command line options 
 directly as `sbt` arguments: any `-Dkey=val` argument will be passed 
-as-is to the JVM, and any `-J-Xfoo` will be passed as `-Xfoo` to the JVM.
+as-is to the JVM, and any `-J-Xfoo` will be passed as `-Xfoo`.
 
 See also `sbt --help` for more details. 
 

--- a/src/reference/01-General-Info/05-Setup-Notes.md
+++ b/src/reference/01-General-Info/05-Setup-Notes.md
@@ -5,50 +5,73 @@ out: Setup-Notes.html
 Setup Notes
 -----------
 
-Some notes on how to set up your `sbt` script.
-
 ### Do not put `sbt-launch.jar` on your classpath.
 
 Do *not* put `sbt-launch.jar` in your `\$SCALA_HOME/lib` directory, your
 project's `lib` directory, or anywhere it will be put on a classpath. It
 isn't a library.
 
+### sbt JVM options and system properties
+
+If the `JAVA_OPTS` and/or `SBT_OPTS` environment variables are defined, 
+their content is passed as command line arguments to the JVM running sbt. 
+
+If a file named `.jvmopt` exists in the  current directory, its content 
+is appended to `JAVA_OPTS` at sbt startup. Similarly, if `.sbtopts` 
+and/or `/etc/sbt/sbtopts` exit, their content is appended to `SBT_OPTS`.
+The default value of `JAVA_OPTS` is `-Dfile.encoding=UTF8`.
+
+You can also specify JVM system properties and command line options 
+directly as `sbt` arguments: any `-Dkey=val` argument will be passed 
+as-is to the JVM, and any `-J-Xfoo` will be passed as `-Xfoo` to the JVM.
+
+See also `sbt --help` for more details. 
+
 ### Terminal encoding
 
 The character encoding used by your terminal may differ from Java's
-default encoding for your platform. In this case, you will need to add
-the option `-Dfile.encoding=<encoding>` in your `sbt` script to set the
-encoding, which might look like:
+default encoding for your platform. In this case, you will need to specify
+the `file.encoding=<encoding>` system property,  which might look like:
 
 ```
-java -Dfile.encoding=UTF8
+export JAVA_OPTS="-Dfile.encoding=Cp1252"
+sbt
 ```
 
-### JVM heap, permgen, and stack sizes
+### sbt JVM heap, permgen, and stack sizes
 
 If you find yourself running out of permgen space or your workstation is
 low on memory, adjust the JVM configuration as you would for any
-application. For example a common set of memory-related options is:
+application. 
+
+For example a common set of memory-related options is:
 
 ```
-java -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled
+export SBT_OPTS="-Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled"
+sbt
+```
+
+Or if you prefer to specify them just for this session:
+
+```
+sbt -J-Xmx1536M -J-Xss1M -J-XX:+CMSClassUnloadingEnabled
 ```
 
 ### Boot directory
 
-`sbt-launch.jar` is just a bootstrap; the actual meat of sbt, and the
-Scala compiler and standard library, are downloaded to the shared
-directory `\$HOME/.sbt/boot/`.
+`sbt` is just a bootstrap; the actual meat of sbt, the
+Scala compiler and standard library are by default downloaded to the 
+shared directory `\$HOME/.sbt/boot/`.
 
 To change the location of this directory, set the `sbt.boot.directory`
-system property in your `sbt` script. A relative path will be resolved
+system property. A relative path will be resolved
 against the current working directory, which can be useful if you want
 to avoid sharing the boot directory between projects. For example, the
 following uses the pre-0.11 style of putting the boot directory in
 `project/boot/`:
 
 ```
-java -Dsbt.boot.directory=project/boot/
+sbt -Dsbt.boot.directory=project/boot/
 ```
 
 ### HTTP/HTTPS/FTP Proxy
@@ -61,17 +84,17 @@ variables. If you are behind a proxy requiring authentication, your
 `ftp.proxyPassword` properties for FTP, or `https.proxyUser` and
 `https.proxyPassword` properties for HTTPS.
 
-For example,
+For example:
 
 ```
-java -Dhttp.proxyUser=username -Dhttp.proxyPassword=mypassword
+sbt -Dhttp.proxyUser=username -Dhttp.proxyPassword=mypassword
 ```
 
 On Windows, your script should set properties for proxy host, port, and
 if applicable, username and password. For example, for HTTP:
 
 ```
-java -Dhttp.proxyHost=myproxy -Dhttp.proxyPort=8080 -Dhttp.proxyUser=username -Dhttp.proxyPassword=mypassword
+sbt -Dhttp.proxyHost=myproxy -Dhttp.proxyPort=8080 -Dhttp.proxyUser=username -Dhttp.proxyPassword=mypassword
 ```
 
 Replace `http` with `https` or `ftp` in the above command line to


### PR DESCRIPTION
The current documentation describes how to pass system properties or JVM options directly as `java` command line arguments, which, if I get things correctly, seems to suggest the user should edit the `sbt` script directly. Since those arguments can now  be specified at the `sbt` command line, I suggest to instruct the user to do that instead. 

Also I couldn't find any mention in the documentation of the mechanism related to `SBT_OPTS` and others, so I figured here would be a good location to describe them?