### PR TITLE
Update SDKMAN installation instructions

### DIFF
--- a/src/includes/install.sh
+++ b/src/includes/install.sh
@@ -1,2 +1,2 @@
-\$ sdk install java \$(sdk list java | grep -o "\b8\.[0-9]*\.[0-9]*\-tem" | head -1)
+\$ sdk install java
 \$ sdk install sbt


### PR DESCRIPTION
The current documentation has the following to determine the Java version when installing through SDKMAN:
```
sdk list java | grep -o "\b8\.[0-9]*\.[0-9]*\-tem" | head -1  
```
When running this, it results in the oldest Temurin version available, currently `8.0.345-tem`. Is this really what we want?

If you do a simple `sdk install java` with no qualifier, it will bring down the LTS version of Temurin which is currently set to `17.0.4-tem`.