### PR TITLE
Add sbt-kind to Community Plugin list

### DIFF
--- a/src/reference/01-General-Info/02-Community-Plugins.md
+++ b/src/reference/01-General-Info/02-Community-Plugins.md
@@ -152,6 +152,7 @@ your plugin to the list.
 - [sbt-riotctl](https://github.com/riot-framework/sbt-riotctl): deploy 
   applications as systemd services directly to a Raspberry Pi, ensuring 
   dependencies (e.g. wiringpi) are met.
+- [sbt-kind](https://github.com/tirithel/sbt-kind): load built docker images into a [kind](https://kind.sigs.k8s.io/) cluster.
   
 #### Utility and system plugins
 


### PR DESCRIPTION
This change will add [sbt-kind](https://github.com/tirithel/sbt-kind) to the list of community plugins.