### PR TITLE
Update Using Sonatype Page

### DIFF
--- a/src/reference/01-General-Info/05-Using-Sonatype.md
+++ b/src/reference/01-General-Info/05-Using-Sonatype.md
@@ -21,38 +21,38 @@ Deploying to sonatype is easy! Just follow these simple steps:
 
 ### Sonatype setup
 
-The reference process for configuring and publishing to Sonatype is 
+The reference process for configuring and publishing to Sonatype is
 described in their [OSSRH Guide][sonatype-ossrhguide].
-In short, you need two publicly available URLs: 
+In short, you need two publicly available URLs:
 
 * the website of the project e.g. https://github.com/sonatype/nexus-public
 * the project's source code e.g. https://github.com/sonatype/nexus-public.git
 
-The [OSSRH Guide][sonatype-ossrhguide] walks you through the required 
-process of setting up the account with Sonatype. It’s as simple as 
-[creating a Sonatype's JIRA account][sonatype-signup] and then a 
-[New Project ticket][sonatype-new-project]. When creating the account, try to 
+The [OSSRH Guide][sonatype-ossrhguide] walks you through the required
+process of setting up the account with Sonatype. It’s as simple as
+[creating a Sonatype's JIRA account][sonatype-signup] and then a
+[New Project ticket][sonatype-new-project]. When creating the account, try to
 use the same domain in your email address that the project is hosted on.
-It makes it easier for Sonatype to validate the relationship with the groupId requested in 
-the ticket, but it is not the only method used to confirm the ownership. 
+It makes it easier for Sonatype to validate the relationship with the groupId requested in
+the ticket, but it is not the only method used to confirm the ownership.
 
 Creation of the *New Project ticket* is as simple as:
 
 * providing the name of the library in the ticket’s subject,
-* naming the groupId for distributing the library (make sure 
-it matches the root package of your code). Sonatype provides
-additional hints on choosing the right groupId for publishing your library in 
-[Choosing your coordinates guide][sonatype-coordinates].
-* providing the SCM and Project URLs to the source code and homepage of the 
-library.
+* naming the groupId for distributing the library (make sure
+  it matches the root package of your code). Sonatype provides
+  additional hints on choosing the right groupId for publishing your library in
+  [Choosing your coordinates guide][sonatype-coordinates].
+* providing the SCM and Project URLs to the source code and homepage of the
+  library.
 
-After creating your Sonatype account on JIRA, you can log in 
+After creating your Sonatype account on JIRA, you can log in
 to the [Nexus Repository Manager][sonatype-nexus] using the same credentials,
-although this is not required in the guide, it can be helpful later to check 
+although this is not required in the guide, it can be helpful later to check
 on published artifacts.
 
-> *Note:* Sonatype advises that responding to a **New Project ticket** might 
-take up to two business days, but in my case it was a few minutes.
+> *Note:* Sonatype advises that responding to a **New Project ticket** might
+> take up to two business days, but in my case it was a few minutes.
 
 ### sbt setup
 
@@ -103,12 +103,12 @@ Distribute the key:
 
 #### step 2: sbt-pgp
 
-With the PGP key you want to use, you can sign the artifacts 
-you want to publish to the Sonatype repository with the [sbt-pgp plugin][sbt-pgp]. Follow 
-the instructions for the plugin and you'll have PGP signed artifacts in no 
+With the PGP key you want to use, you can sign the artifacts
+you want to publish to the Sonatype repository with the [sbt-pgp plugin][sbt-pgp]. Follow
+the instructions for the plugin and you'll have PGP signed artifacts in no
 time.
 
-In short, add the following line to your `~/.sbt/1.0/plugins/gpg.sbt` file to 
+In short, add the following line to your `~/.sbt/1.0/plugins/gpg.sbt` file to
 enable it globally for SBT projects:
 
 ```
@@ -122,7 +122,7 @@ Make sure that the `gpg` command is in PATH available to the sbt.
 #### step 3: Credentials
 
 The credentials for your Sonatype OSSRH account need to be stored
-somewhere safe (*e.g. NOT in the repository*). Common convention is a 
+somewhere safe (*e.g. NOT in the repository*). Common convention is a
 `$global_base$/sonatype.sbt` file, with the following:
 
 ```scala
@@ -139,7 +139,9 @@ password=<your password>
 ```
 
 > *Note:* The first two strings must be `"Sonatype Nexus Repository Manager"`
-and `"oss.sonatype.org"` for Coursier to use the credentials.
+> and `"oss.sonatype.org"` for Coursier to use the credentials. If you are using
+> a new OSSRH account created after February 2021, use `"s01.oss.sonatype.org"`
+> instead of `"oss.sonatype.org"`
 
 #### step 4: Configure build.sbt
 
@@ -161,20 +163,24 @@ ThisBuild / scmInfo := Some(
 )
 ThisBuild / developers := List(
   Developer(
-    id    = "Your identifier",
-    name  = "Your Name",
+    id = "Your identifier",
+    name = "Your Name",
     email = "your@email",
-    url   = url("http://your.url")
+    url = url("http://your.url")
   )
 )
 
 ThisBuild / description := "Some description about your project."
-ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / licenses := List(
+  "Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")
+)
 ThisBuild / homepage := Some(url("https://github.com/example/project"))
 
 // Remove all additional repository other than Maven Central from POM
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishTo := {
+  // For accounts created after Feb 2021:
+  // val nexus = "https://s01.oss.sonatype.org/"
   val nexus = "https://oss.sonatype.org/"
   if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
   else Some("releases" at nexus + "service/local/staging/deploy/maven2")
@@ -182,7 +188,7 @@ ThisBuild / publishTo := {
 ThisBuild / publishMavenStyle := true
 ```
 
-The full format of a `pom.xml` (an end product of the project configuration 
+The full format of a `pom.xml` (an end product of the project configuration
 used by Maven) file is [outlined here](https://maven.apache.org/pom.html).
 You can add more data to it with the `pomExtra` option in `build.sbt`.
 
@@ -206,46 +212,59 @@ Close the staging repository and promote the release to central, by hitting
 
 > *Note:* sbt-sonatype is a third-party plugin meaning it is not covered by Lightbend subscription.
 
-To simplify the usage of the Sonatype's Nexus, add the following line to 
+To simplify the usage of the Sonatype's Nexus, add the following line to
 `project/plugins.sbt` to import the [sbt-sonatype plugin][sbt-sonatype] to your project:
 
 ```
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
 ```
 
-This plugin will facilitate the publishing process, but in short, these are 
+This plugin will facilitate the publishing process, but in short, these are
 the main steps for publishing the libraries to the repository:
 
-1. Create a new staging repository: 
-`sonatypeOpen "your groupId" "Some staging name"`
+1. Create a new staging repository:
+   `sonatypeOpen "your groupId" "Some staging name"`
 2. Sign and publish the library to the staging repository:
-`publishSigned`
+   `publishSigned`
 3. You can and should check the published artifacts in the
-[Nexus Repository Manager][sonatype-nexus] (same login as Sonatype's
-Jira account)
+   [Nexus Repository Manager][sonatype-nexus] (same login as Sonatype's
+   Jira account)
 4. Close the staging repository and promote the release to central:
-`sonatypeRelease`
+   `sonatypeRelease`
+
+Below are some important keys to take note of when using this plugin. [Read here][sbt-sonatype]
+for more information.
+
+```scala
+// This becomes a simplified version of the above key.
+publishTo := sonatypePublishToBundle.value
+// Set this to the same value set as your credential files host.
+sonatypeCredentialHost := "oss.sonatype.org"
+// Set this to the repository to publish to using `s01.oss.sonatype.org`
+// for accounts created after Feb. 2021.
+sonatypeRepository := "https://oss.sonatype.org/service/local"
+```
 
 After publishing you have to follow the
 [release workflow of Nexus](https://central.sonatype.org/publish/release/).
 
-> *Note:* the sbt-sonatype plugin can also be used to publish to other non-sonatype 
-repositories
+> *Note:* the sbt-sonatype plugin can also be used to publish to other non-sonatype
+> repositories
 
 #### Publishing tips
 
-Use staged releases to test across large projects of independent releases 
+Use staged releases to test across large projects of independent releases
 before pushing the full project.
 
 > *Note:* An error message of `PGPException: checksum mismatch at 0 of 20`
-indicates that you got the passphrase wrong. We have found at least on
-OS X that there may be issues with characters outside the 7-bit ASCII
-range (e.g. Umlauts). If you are absolutely sure that you typed the
-right phrase and the error doesn't disappear, try changing the
-passphrase.
+> indicates that you got the passphrase wrong. We have found at least on
+> OS X that there may be issues with characters outside the 7-bit ASCII
+> range (e.g. Umlauts). If you are absolutely sure that you typed the
+> right phrase and the error doesn't disappear, try changing the
+> passphrase.
 
 > *Note:* If you are using a new OSSRH account created after February 2021,
-use `"s01.oss.sonatype.org"` instead of `"oss.sonatype.org"`
+> use `"s01.oss.sonatype.org"` instead of `"oss.sonatype.org"`
 
 #### Integrate with the release process
 


### PR DESCRIPTION
## Description of change:
- Updates `sbt-sonatype` version to `v3.9.13` to support accounts created after Febuary 2021.
- Modified all references of `oss.sonatype.org` to also comment about using `s01.oss.sonatype.org` for newer accounts.
- Ran scalafmt on the file, removed a lot of whitespace. Should we add scalafmt as a buildstep?

**_Added comments to relevant changes, everything else is whitespace._**