### PR TITLE
Clarifies that 'it' is a name and not a pronoun

### DIFF
--- a/src/reference/02-DetailTopics/02-Configuration/14-Testing.md
+++ b/src/reference/02-DetailTopics/02-Configuration/14-Testing.md
@@ -269,7 +269,7 @@ lazy val root = (project in file("."))
 ```
 
 -   `configs(IntegrationTest)` adds the predefined integration test
-    configuration. This configuration is referred to by the name it.
+    configuration. This configuration is referred to by the name `it`. 
 -   `settings(Defaults.itSettings)` adds compilation, packaging,
     and testing actions and settings in the IntegrationTest
     configuration.


### PR DESCRIPTION
When reading this sentence, it was not immediately obvious to me that "it" was actually the name of the configuration, I was interpreting it as a pronoun and was assuming the sentence was just incomplete.

(I'll admit I might just have been a bit slow... ^^)

I suggest to add this simple formatting to make the meaning more explicit.