### PR TITLE
Replace `sonatypeRepo` with `sonatypeOssRepos`

### DIFF
--- a/src/reference/00-Getting-Started/10-Using-Plugins.md
+++ b/src/reference/00-Getting-Started/10-Using-Plugins.md
@@ -47,7 +47,7 @@ plugin's documentation may instruct you to also add the repository where
 it can be found:
 
 ```scala
-resolvers += Resolver.sonatypeRepo("public")
+resolvers ++= Resolver.sonatypeOssRepos("public")
 ```
 
 Plugins usually provide settings that get added to a project to enable

--- a/src/reference/02-DetailTopics/03-Dependency-Management/06-Resolvers.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/06-Resolvers.md
@@ -40,8 +40,8 @@ A few predefined repositories are available and are listed below
     <https://repo1.maven.org/maven2/> and is included by default
 -   `JavaNet2Repository` This is the java.net Maven2 Repository at
     <https://maven.java.net/content/repositories/public/>
--   `Resolver.sonatypeRepo("public")` (or "snapshots", "staging", "releases") This is Sonatype OSS Maven Repository at
-    <https://oss.sonatype.org/content/repositories/public>
+-   `Resolver.sonatypeOssRepos("public")` (or "snapshots", "staging", "releases") This is Sonatype OSS Maven Repository at
+    <https://oss.sonatype.org/content/repositories/public>, <https://s01.oss.sonatype.org/content/repositories>
 -   `Resolver.typesafeRepo("releases")` (or "snapshots") This is Typesafe Repository at
     <https://repo.typesafe.com/typesafe/releases>
 -   `Resolver.typesafeIvyRepo("releases")` (or "snapshots") This is Typesafe Ivy Repository at

--- a/src/reference/es/00-Getting-Started/10-Using-Plugins.md
+++ b/src/reference/es/00-Getting-Started/10-Using-Plugins.md
@@ -36,7 +36,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 No todos los plugins están ubicados en uno de los repositorios predeterminados. La documentación del plugin te puede instar a que añadas el repositorio donde se encuentra:
 
 ```scala
-resolvers += Resolver.sonatypeRepo("public")
+resolvers ++= Resolver.sonatypeOssRepos("public")
 ```
 
 Por lo general los plugins proporcionan configuraciones que son añadidas a la del proyecto para habilitar la funcionalidad del plugin. Esto es explicado en la siguiente sección:

--- a/src/reference/ja/00-Getting-Started/10-Using-Plugins.md
+++ b/src/reference/ja/00-Getting-Started/10-Using-Plugins.md
@@ -45,7 +45,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 プラグインのドキュメントでそのプラグインが見つかるリポジトリを resolvers に追加するよう指示されていることもあるだろう。
 
 ```scala
-resolvers += Resolver.sonatypeRepo("public")
+resolvers ++= Resolver.sonatypeOssRepos("public")
 ```
 
 プラグインは普通、プロジェクトでそのプラグインの機能を有効にするためのセッティング群を提供している。

--- a/src/reference/zh-cn/00-Getting-Started/10-Using-Plugins.md
+++ b/src/reference/zh-cn/00-Getting-Started/10-Using-Plugins.md
@@ -36,7 +36,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 不是所有的插件都在同一个默认的仓库中，而且一个插件的文档会指导你添加能够找到它的仓库：
 
 ```scala
-resolvers += Resolver.sonatypeRepo("public")
+resolvers ++= Resolver.sonatypeOssRepos("public")
 ```
 
 插件通常提供设置将它添加到项目并且开启插件功能。这些将在下一小节描述。


### PR DESCRIPTION
As is the title.
The current document mentions to a deprecated resolver.

refs: 
  - https://github.com/sbt/librarymanagement/pull/393
  - https://github.com/sbt/website/pull/1120

--- 

Thank you :)