### PR TITLE
Remove TOFU in `download`

### DIFF
--- a/src/landing/download.md
+++ b/src/landing/download.md
@@ -14,7 +14,7 @@ sbt --script-version
 
 This should install the latest stable version of `sbt`.
 
- Mac
+Mac
 -----
 
 ### SDKMAN!


### PR DESCRIPTION
It may display correctly on Mac, but it will be TOFU on Windows.

![tofu](https://user-images.githubusercontent.com/11273093/235355319-ba0ec6c4-eba1-49c4-8a79-4a2cefd8bc09.png)
