### PR TITLE
Update "Setup On Ubuntu" section in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ The PDF generation is optional, and requires the following additional steps to i
 #### On Ubuntu
 
 ```
-$ sudo add-apt-repository ppa:texlive-backports/ppa
-$ sudo apt-get update
 $ sudo apt-get install pandoc latex-cjk-all texlive-full
 ```
 


### PR DESCRIPTION
On Ubuntu 20.04 the `ppa:texlive-backports/ppa` repository returns 404.

```sh
$ cat /etc/issue
Ubuntu 20.04.5 LTS \n \l
```

```sh
$ sudo add-apt-repository ppa:texlive-backports/ppa
 Backports of the latest TeX Live from Ubuntu 12.10 to Ubuntu 12.04 LTS
 More info: https://launchpad.net/~texlive-backports/+archive/ubuntu/ppa
Press [ENTER] to continue or Ctrl-c to cancel adding it.

Hit:1 https://download.docker.com/linux/ubuntu focal InRelease
Get:2 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Ign:3 http://ppa.launchpad.net/texlive-backports/ppa/ubuntu focal InRelease
Err:4 http://ppa.launchpad.net/texlive-backports/ppa/ubuntu focal Release
  404  Not Found [IP: xxx.xxx.xxx.xxx xxx]
Hit:5 http://archive.ubuntu.com/ubuntu focal InRelease
Get:6 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:7 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Reading package lists... Done
E: The repository 'http://ppa.launchpad.net/texlive-backports/ppa/ubuntu focal Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

It seems that Ubuntu 18.04+, texlive-full can be used without adding a PPA repository. Actually, I can installed it on Ubuntu 20.04 without adding any PPA.

> https://packages.ubuntu.com/search?lang=en&searchon=names&keywords=texlive-full
> https://launchpad.net/ubuntu/+source/texlive-base
