### PR TITLE
Use `actions/setup-java@v3` instead of `olafurpg/setup-scala@v14` for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Setup
-      uses: olafurpg/setup-scala@v14
+      uses: actions/setup-java@v3
       with:
-        java-version: "adopt@1.8"
+        distribution: 'adopt'
+        java-version: '8'
     - name: Coursier cache
       uses: coursier/cache-action@v6
     - name: Cache sbt


### PR DESCRIPTION
The current GitHub Action `olafurpg/setup-scala@v14` [has been deprecated](https://github.com/olafurpg/setup-scala/releases/tag/v14). This PR purpose is replace it with `actions/setup-java`.

> ctions/setup-java Usage: https://github.com/actions/setup-java#supported-version-syntax

Thank you :)