### PR TITLE
docs: add a link to overriding the publishing convention

### DIFF
--- a/src/reference/02-DetailTopics/03-Dependency-Management/05-Publishing.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/05-Publishing.md
@@ -155,7 +155,7 @@ supported repository types.
 By default sbt will publish your artifact with the binary version of Scala
 you're using. For example if your project is using Scala 2.13.x your example
 artifact would be published under `example_2.13`. This is often what you want,
-but if you're publishing a pure java artifact or a compiler plugin you'll want
+but if you're publishing a pure Java artifact or a compiler plugin you'll want
 to change the `CrossVersion`. See the [Cross Build][Cross-Build] page for more
 details under the _Overriding the publishing convention_ section.
 

--- a/src/reference/02-DetailTopics/03-Dependency-Management/05-Publishing.md
+++ b/src/reference/02-DetailTopics/03-Dependency-Management/05-Publishing.md
@@ -150,6 +150,15 @@ To support multiple incompatible Scala versions, enable cross building
 and do `+ publish` (see [Cross Build][Cross-Build]). See [Resolvers] for other
 supported repository types.
 
+### Overriding the publishing convention
+
+By default sbt will publish your artifact with the binary version of Scala
+you're using. For example if your project is using Scala 2.13.x your example
+artifact would be published under `example_2.13`. This is often what you want,
+but if you're publishing a pure java artifact or a compiler plugin you'll want
+to change the `CrossVersion`. See the [Cross Build][Cross-Build] page for more
+details under the _Overriding the publishing convention_ section.
+
 ### Published artifacts
 
 By default, the main binary jar, a sources jar, and a API documentation


### PR DESCRIPTION
I was helping out someone today and assumed I'd find reference to
`CrossVersion` in the publishing section since they were trying to
publish a java artifact and looking for `CrossVersion.disabled`. However
it's in the cross-build page. This adds a small note in the publishing
page and then links it to the more detailed version in the cross build
page.
