### PR TITLE
Added wayback machine link to blog post

### DIFF
--- a/src/landing/learn.md
+++ b/src/landing/learn.md
@@ -44,7 +44,7 @@ Book(s)
 Blog posts
 ----------
 
-- [Awesome sbt plugins for everyone](https://tech.ovoenergy.com/awesome-sbt-plugins-for-everyone/), 2017, Michael Wizner
+- [Awesome sbt plugins for everyone](https://tech.ovoenergy.com/awesome-sbt-plugins-for-everyone/) ([Internet Archive](https://web.archive.org/web/20230604200723/https://tech.ovoenergy.com/awesome-sbt-plugins-for-everyone/)), 2017, Michael Wizner
 - [parallel cross building using sbt-projectmatrix](https://eed3si9n.com/parallel-cross-building-using-sbt-projectmatrix), 2019, Eugene Yokota
 - [hot source dependencies using sbt-sriracha](https://eed3si9n.com/hot-source-dependencies-using-sbt-sriracha), 2018, Eugene Yokota
 - [removing commas with sbt-nocomma](https://eed3si9n.com/removing-commas-with-sbt-nocomma), 2018, Eugene Yokota


### PR DESCRIPTION
I created [Issue #1168](https://github.com/sbt/website/issues/1168), but I am not sure this PR is the best way to approach this since the real link would still not work.

Perhaps there could be an archived section under the learning page perhaps that refers to the internet archive where possible if the links no longer work?