### PR TITLE
Replace references to Gigahorse library

### DIFF
--- a/src/reference/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/00-Getting-Started/02-sbt-by-example.md
@@ -368,7 +368,7 @@ Press `Enter` to exit the continuous test.
 
 ### Make hello depend on helloCore
 
-Use `.dependsOn(...)` to add a dependency on other subprojects. Also let's move the Gigahorse dependency to `helloCore`.
+Use `.dependsOn(...)` to add a dependency on other subprojects. Also let's move the toolkit dependency to `helloCore`.
 
 @@snip [example-sub4]($root$/src/sbt-test/ref/example-sub4/build.sbt) {}
 

--- a/src/reference/es/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/es/00-Getting-Started/02-sbt-by-example.md
@@ -376,7 +376,7 @@ Pulsa `Intro` para salir del test continuo.
 ### Hacer que hello dependa de helloCore
 
 Usa `.dependsOn(...)` para añadir dependencias sobre otros subproyectos.
-Además, movamos la dependencia de Gigahorse a `helloCore`.
+Además, movamos la dependencia de toolkit a `helloCore`.
 
 @@snip [example-sub4]($root$/src/sbt-test/ref/example-sub4/build.sbt) {}
 

--- a/src/reference/ja/00-Getting-Started/02-sbt-by-example.md
+++ b/src/reference/ja/00-Getting-Started/02-sbt-by-example.md
@@ -360,7 +360,7 @@ sbt:Hello> ~testQuick
 
 ### hello が helloCore に依存するようにする
 
-サブプロジェクト間の依存関係を定義するには `.dependsOn(...)` を使う。ついでに、Gigahorse への依存性も `helloCore` に移そう。
+サブプロジェクト間の依存関係を定義するには `.dependsOn(...)` を使う。ついでに、toolkit への依存性も `helloCore` に移そう。
 
 @@snip [example-sub4]($root$/src/sbt-test/ref/example-sub4/build.sbt) {}
 


### PR DESCRIPTION
The dependency was replaced in 18f165e.

I thought about calling it by its official name "Scala Toolkit", but I guess it's more helpful if it is consistent with how it is referenced below.
