### PR TITLE
fix broken links: add .html route slugs to download, learn, community

### DIFF
--- a/src/pages/404.md
+++ b/src/pages/404.md
@@ -8,7 +8,7 @@ title: "404: Page not found"
 
 * [Home page](/index.html)
 * [Learn](/learn.html)
-* [Downloads](/downloads.html)
+* [Download](/download.html)
 * [StackOverflow](https://stackoverflow.com/questions/tagged/sbt)
 
 ### Help us fix this site

--- a/src/pages/community.md
+++ b/src/pages/community.md
@@ -1,5 +1,6 @@
 ---
 title: Get Involved
+slug: /community.html
 ---
 
   [so]: https://stackoverflow.com/questions/tagged/sbt

--- a/src/pages/cookie.md
+++ b/src/pages/cookie.md
@@ -1,5 +1,6 @@
 ---
 title: Cookie
+slug: /cookie.html
 ---
 
 Your Privacy

--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -1,5 +1,6 @@
 ---
 title: Download
+slug: /download.html
 ---
 
 import { sbtVersion, windowsBuild, downloadUrl } from '@site/variables';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -43,7 +43,7 @@ function SimpleThings() {
 <h3>Hello, world!</h3>
 <pre><code className="language-scala prettyprint"><span className="typ">ThisBuild</span> / scalaVersion := <span className="str">{ '"' + scala3ExampleVersion + '"' }</span>
 </code></pre>
-You just need one line of <code>build.sbt</code> to get started with Scala. Learn more on <a href="1.x/docs/sbt-by-example.html">sbt by Example</a> page.
+You just need one line of <code>build.sbt</code> to get started with Scala. Learn more on <a href="https://www.scala-sbt.org/1.x/docs/sbt-by-example.html">sbt by Example</a> page.
 
 <h3>sbt new</h3>
 Choose from community-maintained <a href="https://github.com/search?o=desc&p=1&q=g8&s=stars&type=Repositories">Giter8 templates</a> to jump start your project:

--- a/src/pages/learn.md
+++ b/src/pages/learn.md
@@ -1,5 +1,6 @@
 ---
 title: Learn
+slug: /learn.html
 ---
 
 Learn

--- a/src/pages/thank-you.md
+++ b/src/pages/thank-you.md
@@ -1,5 +1,6 @@
 ---
 title: Thank you
+slug: /thank-you.html
 ---
 
 Thank You


### PR DESCRIPTION
https://www.scala-sbt.org/download.html currently has a 404, and then it seems a redirect.

With these changes we restore the original links, and it seems the new routes still work

fixes #1181 