### PR TITLE
Fix links to download.html again

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,6 +6,15 @@
 
 import {themes as prismThemes} from 'prism-react-renderer';
 
+import fs from 'fs';
+
+/** the routes of pages in src/pages dir */
+const srcPagesRoutes =
+  fs.readdirSync('src/pages')
+    .filter(f => f.endsWith('.md') || f.endsWith('.mdx'))
+    .map(f => f.replace(/\.mdx?$/, ''))
+    .map(f => '/' + f);
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'sbt',
@@ -148,6 +157,21 @@ const config = {
       },
 
     }),
+
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        createRedirects(existingPath) {
+          // create download.html, learn.html, community.html
+          if (srcPagesRoutes.includes(existingPath)) {
+            return [existingPath + '.html'];
+          }
+          return undefined;
+        }
+      },
+    ]
+  ]
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.1.0",
+    "@docusaurus/plugin-client-redirects": "3.1.0",
     "@docusaurus/preset-classic": "3.1.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,21 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
+"@docusaurus/plugin-client-redirects@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.1.0.tgz#1d107a319d83da24edac0a672681b098129eee8f"
+  integrity sha512-CuFbdciMGvtGYiIPSOpj5idsHOQUcqZWTLCmZV3ePhviekm4dRZm1+QK/BxigmSTL5ICJMGbtOQnz7bgFSWHqg==
+  dependencies:
+    "@docusaurus/core" "3.1.0"
+    "@docusaurus/logger" "3.1.0"
+    "@docusaurus/utils" "3.1.0"
+    "@docusaurus/utils-common" "3.1.0"
+    "@docusaurus/utils-validation" "3.1.0"
+    eta "^2.2.0"
+    fs-extra "^11.1.1"
+    lodash "^4.17.21"
+    tslib "^2.6.0"
+
 "@docusaurus/plugin-content-blog@3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.0.tgz#d2102e9286486e526dbc0dfc741e53dc5cee0ff0"


### PR DESCRIPTION
from Docusaurus config file, generate a map of all the routes and directs extracted from `slug` field in markdown front-matter of files in `src/pages`, then use `@docusaurus/plugin-client-redirects` to generate routes for all those pages so there will be a static route for GitHub pages

fixes https://github.com/sbt/website/issues/1181