### PR TITLE
No need to use lazy val to define a string constant

### DIFF
--- a/src/reference/00-Getting-Started/12-Organizing-Build.md
+++ b/src/reference/00-Getting-Started/12-Organizing-Build.md
@@ -86,7 +86,7 @@ import sbt._
 
 object Dependencies {
   // Versions
-  lazy val akkaVersion = "$example_akka_version$"
+  val akkaVersion = "$example_akka_version$"
 
   // Libraries
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion


### PR DESCRIPTION
Specially when the constant is used immediately after