### PR TITLE
Update `docusaurus.config.js` with corrected `projectName` and GitHub link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,7 +54,7 @@ const config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'sbt', // Usually your GitHub org/user name.
-  projectName: 'website', // Usually your repo name.
+  projectName: 'sbt', // Usually your repo name.
 
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
@@ -112,7 +112,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://github.com/sbt/website',
+            href: 'https://github.com/sbt/sbt',
             label: 'GitHub',
             position: 'right',
           },


### PR DESCRIPTION
Update `docusaurus.config.js` with corrected `projectName` and GitHub link

- The documentation site is for `sbt`, so the `projectName` should be `sbt`, not `website`.
- The GitHub link should direct to the `sbt` repository rather than the `website` repository, as the doc site itself is for sbt.


**This is what I think it should be, but I don't know the intention of the current config, so this PR might make no sense.**