### PR TITLE
Add section on disabling scaladoc

### DIFF
--- a/src/reference/04-Howto/11-Howto-Scaladoc.md
+++ b/src/reference/04-Howto/11-Howto-Scaladoc.md
@@ -107,3 +107,16 @@ apiURL := Some(url("https://example.org/api/"))
 
 This information will get included in a property of the published
 `pom.xml`, where it can be automatically consumed by sbt.
+
+
+<a name="disable-scaladoc"></a>
+
+### Disable scaladoc
+
+If you don't need the Scaladocs to be generated, you can empty 
+the `sources` for `doc` task. This operation is known to improve 
+the build times for projects with a significant number of sources.
+
+```scala
+Compile / doc / sources := List.empty
+```


### PR DESCRIPTION
Disabling scaladoc is known to improve build times for large codebases (example: https://github.com/scala/scala3/pull/18157). Multiple projects do it (example https://github.com/scala/scala/blob/2.13.x/build.sbt#L362) but it doesn't seem to be documented. Hopefully that's useful.

Also please let me know if there are other/better options to do it.