### PR TITLE
Demote cs setup

### DIFF
--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -11,17 +11,17 @@ import HomepageVersions from '@site/src/components/HomepageVersions';
 Download
 ========
 
-Install sbt with **cs setup**
------------------------------
+Universal packages
+------------------
 
-Follow [Install](https://www.scala-lang.org/download/) page, and install Scala using Coursier.
+The most reliable way to install sbt is to use SDKMAN or manually install from the universal packages.
 
-```bash
-cs setup
-sbt --script-version
-```
-
-This should install the latest stable version of `sbt`.
+- <a href={ downloadUrl(sbtVersion, sbtVersion, ".zip") }>sbt-{sbtVersion}.zip</a>
+- <a href={ downloadUrl(sbtVersion, sbtVersion, ".zip.sha256") }>sbt-{sbtVersion}.zip.sha256</a>
+- <a href={ downloadUrl(sbtVersion, sbtVersion, ".zip.asc") }>sbt-{sbtVersion}.zip.asc</a>
+- <a href={ downloadUrl(sbtVersion, sbtVersion, ".tgz") }>sbt-{sbtVersion}.tgz</a>
+- <a href={ downloadUrl(sbtVersion, sbtVersion, ".tgz.sha256") }>sbt-{sbtVersion}.tgz.sha256</a>
+- <a href={ downloadUrl(sbtVersion, sbtVersion, ".tgz.asc") }>sbt-{sbtVersion}.tgz.asc</a>
 
 <Tabs groupId="operating-systems">
   <TabItem value="mac" label="macOS">
@@ -84,15 +84,17 @@ sudo yum install sbt
   </TabItem>
 </Tabs>
 
-Universal packages
-------------------
+Coursier (cs setup)
+-------------------
 
-- <a href={ downloadUrl(sbtVersion, sbtVersion, ".zip") }>sbt-{sbtVersion}.zip</a>
-- <a href={ downloadUrl(sbtVersion, sbtVersion, ".zip.sha256") }>sbt-{sbtVersion}.zip.sha256</a>
-- <a href={ downloadUrl(sbtVersion, sbtVersion, ".zip.asc") }>sbt-{sbtVersion}.zip.asc</a>
-- <a href={ downloadUrl(sbtVersion, sbtVersion, ".tgz") }>sbt-{sbtVersion}.tgz</a>
-- <a href={ downloadUrl(sbtVersion, sbtVersion, ".tgz.sha256") }>sbt-{sbtVersion}.tgz.sha256</a>
-- <a href={ downloadUrl(sbtVersion, sbtVersion, ".tgz.asc") }>sbt-{sbtVersion}.tgz.asc</a>
+:::warning
+Install the latest Coursier before attempting the following steps.
+There are multiple bug reports on `cs setup`. See [coursier#2953](https://github.com/coursier/coursier/issues/2953), [#7278](https://github.com/sbt/sbt/issues/7278) etc.
+:::
+
+```bash
+cs setup
+```
 
 ### Previous releases
 


### PR DESCRIPTION
## Problem
Currently the website puts `cs setup` on the top item as a way of installing sbt, however, the users seem to run into issues with `cs setup`, which is not great for the out-of-box experience of sbt.

## Solution
Promote more reliable way of installing sbt.