### PR TITLE
Update Ubuntu installation instruction

### DIFF
--- a/src/pages/download.mdx
+++ b/src/pages/download.mdx
@@ -65,7 +65,7 @@ Homebrew maintainers have added a dependency to JDK 13 because they want to use 
 ```bash
 echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
 echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo tee /etc/apt/trusted.gpg.d/sbt.asc
 sudo apt-get update
 sudo apt-get install sbt
 ```

--- a/src/reference/es/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/es/00-Getting-Started/01-Setup/c.md
@@ -58,7 +58,7 @@ Ejecuta lo siguiente desde el terminal para instalar `sbt`
 
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo tee /etc/apt/trusted.gpg.d/sbt.asc
     sudo apt-get update
     sudo apt-get install sbt
 

--- a/src/reference/ja/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/ja/00-Getting-Started/01-Setup/c.md
@@ -52,7 +52,7 @@ Ubuntu 及びその他の Debian ベースのディストリビューション�
 
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo tee /etc/apt/trusted.gpg.d/sbt.asc
     sudo apt-get update
     sudo apt-get install sbt
 

--- a/src/reference/zh-cn/00-Getting-Started/01-Setup/c.md
+++ b/src/reference/zh-cn/00-Getting-Started/01-Setup/c.md
@@ -49,7 +49,7 @@ Ubuntu和其他基于Debian的发行版使用DEB格式，但通常你不从本�
 
     echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
     echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo tee /etc/apt/trusted.gpg.d/sbt.asc
     sudo apt-get update
     sudo apt-get install sbt
 


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/8046

## Problem
`sudo apt-key add` is apparently now deprecated,
and the recommended approach is `sudo tee /etc/apt/trusted.gpg.d/sbt.asc`.

## Solution
This switches to the new way.

## Note
Note this instruction will not work on Ubuntu 16.04 LTS (xenial), but hopefully if some are using xenial, they're use to figuring this out by now.