### PR TITLE
Update global_base to "$HOME/.config/sbt/2"

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -30,7 +30,7 @@ scala2_12_example_version = "2.12.21"
 example_munit_version = "1.2.0"
 curly_open = "{{"
 curly_close = "}}"
-global_base="$HOME/.sbt/2"
+global_base="$HOME/.config/sbt/2"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"


### PR DESCRIPTION
The default global base seems to be `$HOME/.config/sbt/2` in sbt 2, but `global_base` still points to `$HOME/.sbt/2`.